### PR TITLE
feat(m1a): durable timer wheel (tests TDD, initially ignored)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,4 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 clap = { version = "4.5", features = ["derive"] }
 uuid = { version = "1", features = ["v4"] }
 chrono = { version = "0.4", default-features = false, features = ["clock", "serde"] }
+humantime = "2.1"

--- a/docs/process/GIT_HOOKS.md
+++ b/docs/process/GIT_HOOKS.md
@@ -1,0 +1,21 @@
+# Git Hooks (Warn-Only)
+
+These local hooks surface hygiene issues without blocking your commit.
+
+- **pre-commit**
+  - Warns on `examples/**/scratch*` files
+  - Warns when staged changes exceed ~200 LOC (total or per file)
+  - Warns if Rust tests contain `#[ignore]` (use `Justify-Ignore:` note in the commit message)
+
+- **commit-msg**
+  - Reminds you to include a `Justify-Ignore:` line when `#[ignore]` is present
+
+Bypass on demand:
+```bash
+SKIP_GIT_HOOKS=1 git commit -m "..."
+```
+
+Customize max LOC:
+```bash
+GIT_HOOKS_WARN_MAX_LINES=250 git commit -m "..."
+```

--- a/engine/src/rituals/log.rs
+++ b/engine/src/rituals/log.rs
@@ -1,0 +1,1 @@
+// placeholder: execution log scaffolding for M1B

--- a/engine/src/rituals/mod.rs
+++ b/engine/src/rituals/mod.rs
@@ -1,5 +1,7 @@
 //! Minimal ritual interpreter for Milestone 0 (single task with end=true)
 
+pub mod timers;
+
 use anyhow::{Context, Result};
 use serde::Deserialize;
 use serde_json::json;

--- a/engine/src/rituals/state.rs
+++ b/engine/src/rituals/state.rs
@@ -1,0 +1,1 @@
+// placeholder: state machine scaffolding for M1B

--- a/engine/src/rituals/timers.rs
+++ b/engine/src/rituals/timers.rs
@@ -1,0 +1,53 @@
+use chrono::{DateTime, Duration, Utc};
+
+#[derive(Clone, Debug)]
+pub struct TimerSpec {
+    pub timer_id: String,
+    pub ritual_id: String,
+    pub run_id: String,
+    pub due_at: DateTime<Utc>,
+    pub delivered: bool,
+}
+
+#[derive(Default)]
+pub struct TimerWheel {
+    specs: Vec<TimerSpec>,
+}
+
+impl TimerWheel {
+    pub fn new() -> Self { Self { specs: Vec::new() } }
+
+    /// For M1A, a simple in-memory schedule API. Persistence comes in M1B.
+    pub fn schedule_in(&mut self, run_id: &str, ritual_id: &str, delay: Duration) -> TimerSpec {
+        let spec = TimerSpec {
+            timer_id: format!("timer-{}", self.specs.len() + 1),
+            ritual_id: ritual_id.to_string(),
+            run_id: run_id.to_string(),
+            due_at: Utc::now() + delay,
+            delivered: false,
+        };
+        self.specs.push(spec.clone());
+        spec
+    }
+
+    /// Tick evaluates timers due at or before `now`.
+    pub fn tick(&mut self, now: DateTime<Utc>) -> Vec<TimerSpec> {
+        self.specs
+            .iter()
+            .filter(|t| !t.delivered && t.due_at <= now)
+            .cloned()
+            .collect()
+    }
+
+    /// Mark a timer as delivered to enforce idempotency at engine layer.
+    pub fn mark_fired(&mut self, timer_id: &str) {
+        if let Some(t) = self.specs.iter_mut().find(|t| t.timer_id == timer_id) {
+            t.delivered = true;
+        }
+    }
+
+    /// Helper to rebuild wheel from known specs (simulated persistence for tests).
+    pub fn from_specs(specs: Vec<TimerSpec>) -> Self {
+        Self { specs }
+    }
+}

--- a/engine/src/rituals/timers.rs
+++ b/engine/src/rituals/timers.rs
@@ -12,18 +12,25 @@ pub struct TimerSpec {
 #[derive(Default)]
 pub struct TimerWheel {
     specs: Vec<TimerSpec>,
+    current_time: Option<DateTime<Utc>>, // For testing: if set, use this instead of Utc::now()
 }
 
 impl TimerWheel {
-    pub fn new() -> Self { Self { specs: Vec::new() } }
+    pub fn new() -> Self { Self { specs: Vec::new(), current_time: None } }
+
+    /// For testing: create wheel with a fixed "current time"
+    pub fn new_with_time(current_time: DateTime<Utc>) -> Self { 
+        Self { specs: Vec::new(), current_time: Some(current_time) }
+    }
 
     /// For M1A, a simple in-memory schedule API. Persistence comes in M1B.
     pub fn schedule_in(&mut self, run_id: &str, ritual_id: &str, delay: Duration) -> TimerSpec {
+        let now = self.current_time.unwrap_or_else(|| Utc::now());
         let spec = TimerSpec {
             timer_id: format!("timer-{}", self.specs.len() + 1),
             ritual_id: ritual_id.to_string(),
             run_id: run_id.to_string(),
-            due_at: Utc::now() + delay,
+            due_at: now + delay,
             delivered: false,
         };
         self.specs.push(spec.clone());
@@ -48,6 +55,6 @@ impl TimerWheel {
 
     /// Helper to rebuild wheel from known specs (simulated persistence for tests).
     pub fn from_specs(specs: Vec<TimerSpec>) -> Self {
-        Self { specs }
+        Self { specs, current_time: None }
     }
 }

--- a/engine/src/rituals/timers.rs
+++ b/engine/src/rituals/timers.rs
@@ -1,4 +1,5 @@
 use chrono::{DateTime, Duration, Utc};
+use uuid::Uuid;
 
 #[derive(Clone, Debug)]
 pub struct TimerSpec {
@@ -35,7 +36,7 @@ impl TimerWheel {
     pub fn schedule_in(&mut self, run_id: &str, ritual_id: &str, delay: Duration) -> TimerSpec {
         let now = self.current_time.unwrap_or_else(|| Utc::now());
         let spec = TimerSpec {
-            timer_id: format!("timer-{}", self.specs.len() + 1),
+            timer_id: Uuid::new_v4().to_string(),
             ritual_id: ritual_id.to_string(),
             run_id: run_id.to_string(),
             due_at: now + delay,

--- a/engine/src/rituals/timers.rs
+++ b/engine/src/rituals/timers.rs
@@ -16,11 +16,19 @@ pub struct TimerWheel {
 }
 
 impl TimerWheel {
-    pub fn new() -> Self { Self { specs: Vec::new(), current_time: None } }
+    pub fn new() -> Self {
+        Self {
+            specs: Vec::new(),
+            current_time: None,
+        }
+    }
 
     /// For testing: create wheel with a fixed "current time"
-    pub fn new_with_time(current_time: DateTime<Utc>) -> Self { 
-        Self { specs: Vec::new(), current_time: Some(current_time) }
+    pub fn new_with_time(current_time: DateTime<Utc>) -> Self {
+        Self {
+            specs: Vec::new(),
+            current_time: Some(current_time),
+        }
     }
 
     /// For M1A, a simple in-memory schedule API. Persistence comes in M1B.
@@ -55,6 +63,9 @@ impl TimerWheel {
 
     /// Helper to rebuild wheel from known specs (simulated persistence for tests).
     pub fn from_specs(specs: Vec<TimerSpec>) -> Self {
-        Self { specs, current_time: None }
+        Self {
+            specs,
+            current_time: None,
+        }
     }
 }

--- a/engine/tests/timer_wheel_spec.rs
+++ b/engine/tests/timer_wheel_spec.rs
@@ -14,10 +14,9 @@ fn schedule_then_no_fire_before_due() {
 }
 
 #[test]
-#[ignore = "implement firing at due time with at-least-once semantics"]
 fn fires_once_at_due_and_marks_delivered() {
     let t0 = Utc.with_ymd_and_hms(2025,1,1,0,0,0).unwrap();
-    let mut wheel = engine::rituals::timers::TimerWheel::new();
+    let mut wheel = engine::rituals::timers::TimerWheel::new_with_time(t0);
     let spec = wheel.schedule_in("run-1", "timer-ritual", Duration::seconds(5));
     // At due time
     let fired1 = wheel.tick(t0 + Duration::seconds(5));

--- a/engine/tests/timer_wheel_spec.rs
+++ b/engine/tests/timer_wheel_spec.rs
@@ -3,10 +3,9 @@ use chrono::{Duration, TimeZone, Utc};
 /// These tests define the expected CONTRACT of the timer wheel for M1A.
 /// They are #[ignore] initially; unignore one by one as you implement (TDD).
 #[test]
-#[ignore = "implement Engine/TimerWheel schedule_in/tick semantics"]
 fn schedule_then_no_fire_before_due() {
     let t0 = Utc.with_ymd_and_hms(2025,1,1,0,0,0).unwrap();
-    let mut wheel = engine::rituals::timers::TimerWheel::new();
+    let mut wheel = engine::rituals::timers::TimerWheel::new_with_time(t0);
     let spec = wheel.schedule_in("run-1", "timer-ritual", Duration::seconds(5));
     assert_eq!(spec.timer_id.len() > 0, true);
     // 3s later: should not fire

--- a/engine/tests/timer_wheel_spec.rs
+++ b/engine/tests/timer_wheel_spec.rs
@@ -29,10 +29,9 @@ fn fires_once_at_due_and_marks_delivered() {
 }
 
 #[test]
-#[ignore = "implement restart-friendly behavior with persisted dueAt (logic only here)"]
 fn restarting_before_due_still_fires_once_after_due() {
     let t0 = Utc.with_ymd_and_hms(2025,1,1,0,0,0).unwrap();
-    let mut wheel = engine::rituals::timers::TimerWheel::new();
+    let mut wheel = engine::rituals::timers::TimerWheel::new_with_time(t0);
     let spec = wheel.schedule_in("run-1", "timer-ritual", Duration::seconds(5));
     // "Restart": re-create the wheel and restore the spec (persistence comes in M1B).
     let mut wheel2 = engine::rituals::timers::TimerWheel::from_specs(vec![spec.clone()]);

--- a/engine/tests/timer_wheel_spec.rs
+++ b/engine/tests/timer_wheel_spec.rs
@@ -41,3 +41,34 @@ fn restarting_before_due_still_fires_once_after_due() {
     let fired = wheel2.tick(t0 + Duration::seconds(5));
     assert_eq!(fired.len(), 1);
 }
+
+#[test]
+fn timer_ids_are_globally_unique_across_restarts() {
+    let t0 = Utc.with_ymd_and_hms(2025, 1, 1, 0, 0, 0).unwrap();
+    let mut wheel = engine::rituals::timers::TimerWheel::new_with_time(t0);
+    
+    // Schedule first timer
+    let spec1 = wheel.schedule_in("run-1", "ritual-1", Duration::seconds(5));
+    
+    // Fire and mark delivered (simulates delivery)
+    wheel.mark_fired(&spec1.timer_id);
+    
+    // Simulate restart: rebuild wheel from specs (delivered timers filtered out)
+    let remaining_specs: Vec<_> = wheel.tick(t0 + Duration::seconds(10))
+        .into_iter()
+        .filter(|s| !s.delivered)
+        .collect();
+    
+    let mut wheel2 = engine::rituals::timers::TimerWheel::from_specs(remaining_specs);
+    
+    // Schedule new timer after restart
+    let spec2 = wheel2.schedule_in("run-2", "ritual-2", Duration::seconds(3));
+    
+    // Timer IDs must be different to prevent confusion
+    assert_ne!(spec1.timer_id, spec2.timer_id, 
+        "Timer IDs must be globally unique even after restart");
+    
+    // Both should be valid UUID format
+    assert!(spec1.timer_id.len() > 10, "Timer ID should be UUID-like");
+    assert!(spec2.timer_id.len() > 10, "Timer ID should be UUID-like");
+}

--- a/engine/tests/timer_wheel_spec.rs
+++ b/engine/tests/timer_wheel_spec.rs
@@ -4,7 +4,7 @@ use chrono::{Duration, TimeZone, Utc};
 /// They are #[ignore] initially; unignore one by one as you implement (TDD).
 #[test]
 fn schedule_then_no_fire_before_due() {
-    let t0 = Utc.with_ymd_and_hms(2025,1,1,0,0,0).unwrap();
+    let t0 = Utc.with_ymd_and_hms(2025, 1, 1, 0, 0, 0).unwrap();
     let mut wheel = engine::rituals::timers::TimerWheel::new_with_time(t0);
     let spec = wheel.schedule_in("run-1", "timer-ritual", Duration::seconds(5));
     assert_eq!(spec.timer_id.len() > 0, true);
@@ -15,7 +15,7 @@ fn schedule_then_no_fire_before_due() {
 
 #[test]
 fn fires_once_at_due_and_marks_delivered() {
-    let t0 = Utc.with_ymd_and_hms(2025,1,1,0,0,0).unwrap();
+    let t0 = Utc.with_ymd_and_hms(2025, 1, 1, 0, 0, 0).unwrap();
     let mut wheel = engine::rituals::timers::TimerWheel::new_with_time(t0);
     let spec = wheel.schedule_in("run-1", "timer-ritual", Duration::seconds(5));
     // At due time
@@ -30,7 +30,7 @@ fn fires_once_at_due_and_marks_delivered() {
 
 #[test]
 fn restarting_before_due_still_fires_once_after_due() {
-    let t0 = Utc.with_ymd_and_hms(2025,1,1,0,0,0).unwrap();
+    let t0 = Utc.with_ymd_and_hms(2025, 1, 1, 0, 0, 0).unwrap();
     let mut wheel = engine::rituals::timers::TimerWheel::new_with_time(t0);
     let spec = wheel.schedule_in("run-1", "timer-ritual", Duration::seconds(5));
     // "Restart": re-create the wheel and restore the spec (persistence comes in M1B).


### PR DESCRIPTION
Implements REQUEST-M1A (Durable Timer Wheel).

- Moves timer work off main into a feature branch
- Keeps placeholder state/log stubs as comment-only to avoid clippy warnings
- Ensures repo hygiene (no scratch examples on main)
- Tests will be unignored and enabled as functionality lands

## Checklists

**Contracts**
- [ ] Event/WIT changes documented and versioned (timer.*:v1)
- [ ] Golden fixtures updated in `contracts/fixtures/events/`

**Tests (red→green)**
- [ ] Unit tests for schedule/tick/mark_fired
- [ ] Integration test for restart-before-due
- [ ] Contract validation added when events are emitted in M1B

**Repo hygiene**
- [x] Small commits (≤200 LOC)
- [ ] Docs updated if APIs change
- [ ] CI green on this branch