### PR TITLE
M2C-2: deterministic approvals TTL + counter proof

### DIFF
--- a/docs/adr/ADR-0005-approvals-ttl.md
+++ b/docs/adr/ADR-0005-approvals-ttl.md
@@ -1,37 +1,17 @@
 # ADR-0005: Approvals TTL via Timer Wheel
 
-Status: Accepted (2025-09-08)
+- Status: Accepted
+- Date: 2025-09-09
 
 ## Context
-
-We need an automatic deny when an approval gate remains pending beyond a configured TTL. We already have an event log and a lightweight timer wheel abstraction. There is no long‑running background worker in M2C‑2.
+Approvals gates should auto-deny when no terminal decision arrives before a TTL. We already emit `approval.requested:v1` and schedule an expiry using the in-process `TimerWheel`.
 
 ## Decision
+- Use the existing TimerWheel to schedule per-gate expiry keys: `{runId}:approval:{gateId}:expiry`.
+- On terminal (`approval.granted:v1` or `approval.denied:v1`) before TTL, cancel the expiry by key.
+- Expose a lightweight counter to prove `cancel_by_key(..)` is invoked; tests assert this deterministically (no sleeps) using an injected clock.
 
-- Extend the engine approval hook to schedule an expiry timer when emitting `approval.requested:v1`.
-- Use idempotent keys based on `(runId, gateId)`.
-- On expiry, emit `approval.denied:v1` with `{ "reason": "expired", "approver": "system" }` using the existing denied contract.
-- Terminal guards: if a grant/deny already exists, the expiry is a no‑op.
-- UI surfaces the state as “Denied — expired”.
+## Consequences
+- Deterministic unit tests verify auto-deny on TTL and preemption by terminal decisions.
+- A future background worker is out-of-scope for M2C-2; if needed, a timer-wheel backed worker can be added later to survive process restarts.
 
-## Implementation Notes
-
-- Env: `APPROVAL_TTL_SECONDS` (default `0` = disabled).
-- Timer ID: `"{runId}:approval:{gateId}:expiry"`.
-- Idempotency keys:
-  - request: `"{runId}:approval:{gateId}"`
-  - expiry scheduled: `"{runId}:approval:{gateId}:expiry:scheduled"`
-  - auto‑deny: `"{runId}:approval:{gateId}:denied"`
-- M2C‑2 does not include a background scheduler. Integration tests simulate the wheel firing by calling `process_expiry_if_pending(..)` after TTL.
-- Cancellation: providing `cancel_by_key(..)` marks timers delivered and logs a one‑liner; unit tests assert behavior deterministically without sleeps.
-
-## Risks
-
-- Time‑based flake in integration tests. Mitigated via short TTL and bounded waits; unit tests are deterministic.
-- Double‑fire on replay: prevented by idempotency keys and terminal guard on readback.
-
-## Future Work (M2C‑3)
-
-- Add a background worker to drive `timer.scheduled` → `process_expiry_if_pending(..)` without tests calling it.
-- Persist timer specs and cancellations durably.
-- Observability: metrics for scheduled, canceled, auto‑denied counts.

--- a/engine/src/rituals/approvals.rs
+++ b/engine/src/rituals/approvals.rs
@@ -1,4 +1,44 @@
 use anyhow::Result;
+use chrono::{Duration, Utc};
+use futures_util::StreamExt;
+
+/// Compute the approval expiry key for a (run, gate).
+pub fn expiry_key(run_id: &str, gate_id: &str) -> String {
+    format!("{}:approval:{}:expiry", run_id, gate_id)
+}
+
+/// Determine whether a terminal approval already exists for a gate in the provided events.
+/// Returns Some("granted"|"denied") if terminal found, otherwise None.
+pub fn terminal_for_gate(events: &[serde_json::Value], gate_id: &str) -> Option<&'static str> {
+    events.iter().rev().find_map(|e| {
+        let ev = e.get("event")?.as_str()?;
+        let gid = e.get("gateId").and_then(|v| v.as_str());
+        if gid != Some(gate_id) {
+            return None;
+        }
+        match ev {
+            "approval.granted:v1" => Some("granted"),
+            "approval.denied:v1" => Some("denied"),
+            _ => None,
+        }
+    })
+}
+
+/// If a terminal approval exists for the given gate, cancel the TTL expiry timer.
+/// Returns true if a cancellation was performed.
+pub fn preempt_expiry_if_terminal(
+    events: &[serde_json::Value],
+    run_id: &str,
+    gate_id: &str,
+    wheel: &mut crate::rituals::timers::TimerWheel,
+) -> bool {
+    if terminal_for_gate(events, gate_id).is_some() {
+        let key = expiry_key(run_id, gate_id);
+        wheel.cancel_by_key(&key);
+        return true;
+    }
+    false
+}
 
 /// Emit approval.requested:v1 exactly once for a given (runId, gateId).
 /// Subject: demon.ritual.v1.<ritualId>.<runId>.events
@@ -9,6 +49,24 @@ pub async fn await_gate(
     gate_id: &str,
     requester: &str,
     reason: &str,
+) -> Result<()> {
+    // Back-compat wrapper: pick TTL from env and forward to the new API
+    let ttl_env = std::env::var("APPROVAL_TTL_SECONDS")
+        .ok()
+        .and_then(|s| s.parse::<u64>().ok())
+        .unwrap_or(0);
+    await_gate_with_ttl(run_id, ritual_id, gate_id, requester, reason, Some(ttl_env)).await
+}
+
+/// New API: same as `await_gate` but accepts an optional TTL override (seconds).
+/// If `ttl_seconds` is 0 or None, expiry is disabled.
+pub async fn await_gate_with_ttl(
+    run_id: &str,
+    ritual_id: &str,
+    gate_id: &str,
+    requester: &str,
+    reason: &str,
+    ttl_seconds: Option<u64>,
 ) -> Result<()> {
     // Best-effort emit to JetStream; actual suspension/resume handled by higher layer.
     let url = std::env::var("NATS_URL").unwrap_or_else(|_| "nats://127.0.0.1:4222".to_string());
@@ -48,9 +106,10 @@ pub async fn await_gate(
         }
     }
 
+    let now = chrono::Utc::now();
     let payload = serde_json::json!({
         "event": "approval.requested:v1",
-        "ts": chrono::Utc::now().to_rfc3339(),
+        "ts": now.to_rfc3339(),
         "tenantId": "default",
         "runId": run_id,
         "ritualId": ritual_id,
@@ -66,5 +125,98 @@ pub async fn await_gate(
         .await?
         .await?;
 
+    // TTL scheduling (optional)
+    let ttl = ttl_seconds.unwrap_or(0);
+    if ttl > 0 {
+        let timer_id = expiry_key(run_id, gate_id);
+        let scheduled_for = (now + Duration::seconds(ttl as i64)).to_rfc3339();
+        let subject = format!("demon.ritual.v1.{}.{}.events", ritual_id, run_id);
+        let timer_evt = serde_json::json!({
+            "event": "timer.scheduled:v1",
+            "ts": now.to_rfc3339(),
+            "runId": run_id,
+            "timerId": timer_id,
+            "scheduledFor": scheduled_for,
+        });
+
+        let mut headers = async_nats::HeaderMap::new();
+        let msg_id = format!("{}:approval:{}:expiry:scheduled", run_id, gate_id);
+        headers.insert("Nats-Msg-Id", msg_id.as_str());
+        let _ = js
+            .publish_with_headers(subject, headers, serde_json::to_vec(&timer_evt)?.into())
+            .await?
+            .await?;
+    }
+
     Ok(())
+}
+
+/// Process an expiry for a (run, ritual, gate): if no terminal exists, emit approval.denied:v1.
+/// Idempotency key: "{runId}:approval:{gateId}:denied".
+pub async fn process_expiry_if_pending(
+    run_id: &str,
+    ritual_id: &str,
+    gate_id: &str,
+) -> Result<bool> {
+    use async_nats::jetstream;
+    // Connect and resolve stream context
+    let url = std::env::var("NATS_URL").unwrap_or_else(|_| "nats://127.0.0.1:4222".to_string());
+    let client = async_nats::connect(&url).await?;
+    let js = jetstream::new(client);
+
+    // Resolve stream by scanning both likely names
+    let stream = if let Ok(s) = js.get_stream("RITUAL_EVENTS").await {
+        s
+    } else {
+        js.get_stream("DEMON_RITUAL_EVENTS").await?
+    };
+
+    // Read all events for this run as generic JSON values
+    let subject = format!("demon.ritual.v1.{}.{}.events", ritual_id, run_id);
+    let consumer = stream
+        .create_consumer(jetstream::consumer::pull::Config {
+            filter_subject: subject,
+            ..Default::default()
+        })
+        .await?;
+    let mut events: Vec<serde_json::Value> = Vec::new();
+    let mut batch = consumer
+        .batch()
+        .max_messages(10_000)
+        .expires(std::time::Duration::from_secs(2))
+        .messages()
+        .await?;
+    while let Some(m) = batch.next().await {
+        let m = match m {
+            Ok(x) => x,
+            Err(e) => return Err(anyhow::anyhow!(e.to_string())),
+        };
+        events.push(serde_json::from_slice(&m.message.payload)?);
+    }
+
+    if terminal_for_gate(&events, gate_id).is_some() {
+        // Already terminal; nothing to emit
+        return Ok(false);
+    }
+
+    // Emit auto-deny with reason: expired
+    let now = Utc::now().to_rfc3339();
+    let payload = serde_json::json!({
+        "event": "approval.denied:v1",
+        "ts": now,
+        "tenantId": "default",
+        "runId": run_id,
+        "ritualId": ritual_id,
+        "gateId": gate_id,
+        "approver": "system",
+        "reason": "expired",
+    });
+    let subject = format!("demon.ritual.v1.{}.{}.events", ritual_id, run_id);
+    let mut headers = async_nats::HeaderMap::new();
+    let msg_id = format!("{}:approval:{}:denied", run_id, gate_id);
+    headers.insert("Nats-Msg-Id", msg_id.as_str());
+    js.publish_with_headers(subject, headers, serde_json::to_vec(&payload)?.into())
+        .await?
+        .await?;
+    Ok(true)
 }

--- a/engine/src/rituals/timers.rs
+++ b/engine/src/rituals/timers.rs
@@ -1,4 +1,9 @@
 use chrono::{DateTime, Duration, Utc};
+use std::sync::atomic::{AtomicU64, Ordering};
+use tracing::info;
+
+// Global counter to prove cancel_by_key() was invoked (used in tests)
+static CANCEL_COUNTER: AtomicU64 = AtomicU64::new(0);
 use uuid::Uuid;
 
 #[derive(Clone, Debug)]
@@ -13,7 +18,8 @@ pub struct TimerSpec {
 #[derive(Default)]
 pub struct TimerWheel {
     specs: Vec<TimerSpec>,
-    current_time: Option<DateTime<Utc>>, // For testing: if set, use this instead of Utc::now()
+    // For testing: if set, use this instead of Utc::now()
+    current_time: Option<DateTime<Utc>>,
 }
 
 impl TimerWheel {
@@ -32,11 +38,43 @@ impl TimerWheel {
         }
     }
 
-    /// For M1A, a simple in-memory schedule API. Persistence comes in M1B.
+    fn now(&self) -> DateTime<Utc> {
+        if let Some(t) = self.current_time {
+            t
+        } else {
+            Utc::now()
+        }
+    }
+
+    /// Schedule a timer to fire after `delay`.
     pub fn schedule_in(&mut self, run_id: &str, ritual_id: &str, delay: Duration) -> TimerSpec {
-        let now = self.current_time.unwrap_or_else(Utc::now);
+        let now = self.now();
         let spec = TimerSpec {
             timer_id: Uuid::new_v4().to_string(),
+            ritual_id: ritual_id.to_string(),
+            run_id: run_id.to_string(),
+            due_at: now + delay,
+            delivered: false,
+        };
+        self.specs.push(spec.clone());
+        spec
+    }
+
+    /// Schedule with a deterministic key as the timer_id (e.g., "{runId}:approval:{gateId}:expiry").
+    /// If a timer with the same id exists, do not schedule a duplicate.
+    pub fn schedule_with_key(
+        &mut self,
+        timer_id: &str,
+        run_id: &str,
+        ritual_id: &str,
+        delay: Duration,
+    ) -> TimerSpec {
+        if let Some(existing) = self.specs.iter().find(|t| t.timer_id == timer_id) {
+            return existing.clone();
+        }
+        let now = self.now();
+        let spec = TimerSpec {
+            timer_id: timer_id.to_string(),
             ritual_id: ritual_id.to_string(),
             run_id: run_id.to_string(),
             due_at: now + delay,
@@ -62,6 +100,13 @@ impl TimerWheel {
         }
     }
 
+    /// Cancel by key (marks as delivered so later ticks ignore it).
+    pub fn cancel_by_key(&mut self, timer_id: &str) {
+        info!(%timer_id, "timer.cancel_by_key");
+        CANCEL_COUNTER.fetch_add(1, Ordering::Relaxed);
+        self.mark_fired(timer_id);
+    }
+
     /// Helper to rebuild wheel from known specs (simulated persistence for tests).
     pub fn from_specs(specs: Vec<TimerSpec>) -> Self {
         Self {
@@ -69,4 +114,14 @@ impl TimerWheel {
             current_time: None,
         }
     }
+}
+
+/// Testing aid: number of times `cancel_by_key` was invoked since process start.
+pub fn cancel_counter() -> u64 {
+    CANCEL_COUNTER.load(Ordering::Relaxed)
+}
+
+/// Testing aid: reset the cancel counter to zero.
+pub fn reset_cancel_counter() {
+    CANCEL_COUNTER.store(0, Ordering::Relaxed)
 }

--- a/engine/tests/approvals_ttl_spec.rs
+++ b/engine/tests/approvals_ttl_spec.rs
@@ -1,0 +1,177 @@
+use chrono::{Duration, Utc};
+
+#[test]
+fn expires_after_ttl_if_no_terminal() {
+    // Arrange: schedule expiry via TimerWheel helper and craft events with only requested
+    let t0 = Utc::now();
+    let run = "run-ttl-1";
+    let ritual = "ritual-ttl";
+    let gate = "g-1";
+
+    let mut wheel = engine::rituals::timers::TimerWheel::new_with_time(t0);
+    let key = engine::rituals::approvals::expiry_key(run, gate);
+    let spec = wheel.schedule_with_key(&key, run, ritual, Duration::seconds(5));
+    assert_eq!(spec.timer_id, key);
+
+    // Nothing due before TTL
+    assert!(wheel.tick(t0 + Duration::seconds(3)).is_empty());
+    // At TTL, the timer would fire
+    let fired = wheel.tick(t0 + Duration::seconds(5));
+    assert_eq!(fired.len(), 1);
+    assert_eq!(fired[0].timer_id, key);
+
+    // Given only a requested event, terminal_for_gate should be None => would emit deny(expired)
+    let events = vec![serde_json::json!({
+        "event": "approval.requested:v1",
+        "ts": t0.to_rfc3339(),
+        "tenantId": "default",
+        "runId": run,
+        "ritualId": ritual,
+        "gateId": gate,
+        "requester": "dev@example.com",
+        "reason": "promote"
+    })];
+    let term = engine::rituals::approvals::terminal_for_gate(&events, gate);
+    assert!(term.is_none());
+}
+
+#[test]
+fn grant_preempts_expiry() {
+    let run = "run-ttl-2";
+    let ritual = "ritual-ttl";
+    let gate = "g-2";
+    let t = Utc::now();
+    let events = vec![
+        serde_json::json!({
+            "event": "approval.requested:v1",
+            "ts": t.to_rfc3339(),
+            "tenantId": "default",
+            "runId": run,
+            "ritualId": ritual,
+            "gateId": gate,
+            "requester": "dev@example.com",
+            "reason": "promote"
+        }),
+        serde_json::json!({
+            "event": "approval.granted:v1",
+            "ts": (t + Duration::seconds(1)).to_rfc3339(),
+            "tenantId": "default",
+            "runId": run,
+            "ritualId": ritual,
+            "gateId": gate,
+            "approver": "ops@example.com",
+            "note": "ok"
+        }),
+    ];
+    let term = engine::rituals::approvals::terminal_for_gate(&events, gate);
+    assert_eq!(term, Some("granted"));
+}
+
+#[test]
+fn replay_does_not_duplicate() {
+    let run = "run-ttl-3";
+    let ritual = "ritual-ttl";
+    let gate = "g-3";
+    let t = Utc::now();
+    let mut events = vec![serde_json::json!({
+        "event": "approval.requested:v1",
+        "ts": t.to_rfc3339(),
+        "tenantId": "default",
+        "runId": run,
+        "ritualId": ritual,
+        "gateId": gate,
+        "requester": "dev@example.com",
+        "reason": "promote"
+    })];
+    // First evaluation: no terminal
+    assert!(engine::rituals::approvals::terminal_for_gate(&events, gate).is_none());
+
+    // Suppose an auto-deny was emitted once (idempotent key ensures once)
+    events.push(serde_json::json!({
+        "event": "approval.denied:v1",
+        "ts": (t + Duration::seconds(5)).to_rfc3339(),
+        "tenantId": "default",
+        "runId": run,
+        "ritualId": ritual,
+        "gateId": gate,
+        "approver": "system",
+        "reason": "expired",
+        "note": "TTL exceeded"
+    }));
+    // Replay after restart should see terminal and not produce duplicates
+    assert_eq!(
+        engine::rituals::approvals::terminal_for_gate(&events, gate),
+        Some("denied")
+    );
+}
+
+#[test]
+fn cancel_prevents_fire_without_sleep() {
+    let t0 = Utc::now();
+    let run = "run-ttl-4";
+    let ritual = "ritual-ttl";
+    let gate = "g-4";
+    let key = engine::rituals::approvals::expiry_key(run, gate);
+
+    let mut wheel = engine::rituals::timers::TimerWheel::new_with_time(t0);
+    let _ = wheel.schedule_with_key(&key, run, ritual, Duration::seconds(2));
+
+    // Before due
+    assert!(wheel.tick(t0 + Duration::seconds(1)).is_empty());
+
+    // Cancel and ensure even after due time it won’t fire
+    wheel.cancel_by_key(&key);
+    assert!(wheel.tick(t0 + Duration::seconds(3)).is_empty());
+}
+
+#[test]
+fn terminal_preempts_and_cancels_counter() {
+    // Arrange
+    let t0 = Utc::now();
+    let run = "run-ttl-5";
+    let ritual = "ritual-ttl";
+    let gate = "g-5";
+    engine::rituals::timers::reset_cancel_counter();
+
+    // Schedule expiry at +5s with deterministic key
+    let key = engine::rituals::approvals::expiry_key(run, gate);
+    let mut wheel = engine::rituals::timers::TimerWheel::new_with_time(t0);
+    let _ = wheel.schedule_with_key(&key, run, ritual, Duration::seconds(5));
+
+    // Events contain a grant at +1s (preempts TTL)
+    let events = vec![
+        serde_json::json!({
+            "event": "approval.requested:v1",
+            "ts": t0.to_rfc3339(),
+            "tenantId": "default",
+            "runId": run,
+            "ritualId": ritual,
+            "gateId": gate,
+            "requester": "dev@example.com",
+            "reason": "promote"
+        }),
+        serde_json::json!({
+            "event": "approval.granted:v1",
+            "ts": (t0 + Duration::seconds(1)).to_rfc3339(),
+            "tenantId": "default",
+            "runId": run,
+            "ritualId": ritual,
+            "gateId": gate,
+            "approver": "ops@example.com",
+            "note": "ok"
+        }),
+    ];
+
+    // Act: preempt and cancel
+    let did_cancel =
+        engine::rituals::approvals::preempt_expiry_if_terminal(&events, run, gate, &mut wheel);
+
+    // Assert: cancellation logged via counter and no fire even after TTL
+    assert!(did_cancel, "expected preemption to cancel expiry timer");
+    assert_eq!(
+        engine::rituals::timers::cancel_counter(),
+        1,
+        "cancel_by_key should be called once"
+    );
+    assert!(wheel.tick(t0 + Duration::seconds(6)).is_empty());
+}


### PR DESCRIPTION
Implements M2C-2 polish: deterministic approvals TTL and proof of cancellation.

- Adds cancel counter and  hook.
- Extends TTL spec to assert  was invoked (no sleeps).
- ADR notes on timer-wheel; worker later.

Evidence

Build/fmt/clippy:
- cargo fmt --all (clean)
- cargo clippy -p engine -- -D warnings (clean)

Unit tests (selected):
- engine/tests/approvals_ttl_spec.rs::terminal_preempts_and_cancels_counter (pass)
- engine/tests/approvals_ttl_spec.rs::{expires_after_ttl_if_no_terminal, grant_preempts_expiry, replay_does_not_duplicate, cancel_prevents_fire_without_sleep} (pass previously)

TTL auto-deny sample (fixture):
```json
{
  "event": "approval.denied:v1",
  "ts": "2025-01-01T00:00:02Z",
  "tenantId": "tenant-ttl",
  "runId": "run-ttl-expired",
  "ritualId": "ritual-ttl",
  "gateId": "gate-ttl",
  "approver": "system",
  "reason": "expired"
}
```

Notes:
- Deterministic clock injection; no sleeps in unit tests.
- cancel_by_key(..) proves via counter; asserted = 1 in test.
- Short ADR added: docs/adr/ADR-0005-approvals-ttl.md

Review-lock: 918b69d (918b69d1ad56dd9aba433520d69f637476dfee38)