### PR TITLE
feat(m2c-3): TTL worker (durable consumer for timer.scheduled)

### DIFF
--- a/docs/adr/ADR-0006-ttl-worker.md
+++ b/docs/adr/ADR-0006-ttl-worker.md
@@ -1,0 +1,26 @@
+# ADR-0006: TTL Worker (Durable Consumer)
+
+- Status: Accepted
+- Date: 2025-09-09
+
+## Context
+Approvals with TTL should auto-deny at due time without manual intervention. JetStream carries timer.scheduled:v1 events on the ritual events subject.
+
+## Decision
+- Add a minimal single-threaded worker that consumes `timer.scheduled:v1` from a durable pull consumer (`TTL_CONSUMER_NAME`, default `ttl-worker`).
+- Filter to `demon.ritual.v1.*.*.events` and parse only timer ids of the form `{runId}:approval:{gateId}:expiry`.
+- Call `process_expiry_if_pending(..)` and ack on success or terminal-noop; leave unacked on error for retry.
+
+## Consequences
+- At-least-once processing with idempotent effects per run/gate.
+- Restart-safe via durable consumer.
+
+## Config
+- `TTL_WORKER_ENABLED=0|1` (default off)
+- `RITUAL_STREAM_NAME` (optional; falls back to `RITUAL_EVENTS` then `DEMON_RITUAL_EVENTS`)
+- `TTL_CONSUMER_NAME` (default `ttl-worker`)
+- `TTL_BATCH` (default 100), `TTL_PULL_TIMEOUT_MS` (default 1500)
+
+## Out of Scope
+- Horizontal scaling and per-tenant sharding (future slice).
+

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -19,6 +19,7 @@ async-nats = { workspace = true }
 tokio = { workspace = true }
 futures-util = { workspace = true }
 wards = { path = "../wards" }
+tracing-subscriber = { workspace = true }
 
 [dev-dependencies]
 jsonschema = { workspace = true }

--- a/engine/src/bin/demon-ttl-worker.rs
+++ b/engine/src/bin/demon-ttl-worker.rs
@@ -1,0 +1,13 @@
+use engine::rituals::worker::ttl_worker::{run_loop, TtlWorkerConfig};
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt::init();
+    let enabled = std::env::var("TTL_WORKER_ENABLED").unwrap_or_else(|_| "0".to_string()) == "1";
+    if !enabled {
+        println!("TTL worker disabled (set TTL_WORKER_ENABLED=1 to start)");
+        return Ok(());
+    }
+    let cfg = TtlWorkerConfig::default();
+    run_loop(cfg).await
+}

--- a/engine/src/rituals/approvals.rs
+++ b/engine/src/rituals/approvals.rs
@@ -40,6 +40,17 @@ pub fn preempt_expiry_if_terminal(
     false
 }
 
+/// Parse an approvals expiry timer id of the form "{runId}:approval:{gateId}:expiry".
+/// Returns Some((run_id, gate_id)) if the format matches, otherwise None.
+pub fn parse_approval_expiry_timer_id(timer_id: &str) -> Option<(String, String)> {
+    let parts: Vec<&str> = timer_id.split(':').collect();
+    if parts.len() == 4 && parts[1] == "approval" && parts[3] == "expiry" {
+        Some((parts[0].to_string(), parts[2].to_string()))
+    } else {
+        None
+    }
+}
+
 /// Emit approval.requested:v1 exactly once for a given (runId, gateId).
 /// Subject: demon.ritual.v1.<ritualId>.<runId>.events
 /// Idempotency: Nats-Msg-Id = "<runId>:approval:<gateId>"

--- a/engine/src/rituals/worker/mod.rs
+++ b/engine/src/rituals/worker/mod.rs
@@ -1,0 +1,1 @@
+pub mod ttl_worker;

--- a/engine/src/rituals/worker/ttl_worker.rs
+++ b/engine/src/rituals/worker/ttl_worker.rs
@@ -1,0 +1,237 @@
+use anyhow::Result;
+use async_nats::jetstream;
+use async_nats::jetstream::Message;
+use futures_util::StreamExt;
+use std::sync::atomic::{AtomicU64, Ordering};
+use tracing::{error, info, warn};
+
+static HANDLED: AtomicU64 = AtomicU64::new(0);
+static EXPIRED: AtomicU64 = AtomicU64::new(0);
+static NOOP: AtomicU64 = AtomicU64::new(0);
+
+#[derive(Clone, Debug)]
+pub struct TtlWorkerConfig {
+    pub nats_url: String,
+    pub stream_name: Option<String>,
+    pub consumer_name: String,  // default: ttl-worker
+    pub subject_filter: String, // default: demon.ritual.v1.*.*.events
+    pub batch: usize,           // default: 100
+    pub pull_timeout_ms: u64,   // default: 1500
+}
+
+impl Default for TtlWorkerConfig {
+    fn default() -> Self {
+        Self {
+            nats_url: std::env::var("NATS_URL")
+                .unwrap_or_else(|_| "nats://127.0.0.1:4222".to_string()),
+            stream_name: std::env::var("RITUAL_STREAM_NAME").ok(),
+            consumer_name: std::env::var("TTL_CONSUMER_NAME")
+                .unwrap_or_else(|_| "ttl-worker".to_string()),
+            subject_filter: "demon.ritual.v1.*.*.events".to_string(),
+            batch: std::env::var("TTL_BATCH")
+                .ok()
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(100),
+            pull_timeout_ms: std::env::var("TTL_PULL_TIMEOUT_MS")
+                .ok()
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(1500),
+        }
+    }
+}
+
+fn incr(a: &AtomicU64) {
+    a.fetch_add(1, Ordering::Relaxed);
+}
+
+pub fn counters() -> (u64, u64, u64) {
+    (
+        HANDLED.load(Ordering::Relaxed),
+        EXPIRED.load(Ordering::Relaxed),
+        NOOP.load(Ordering::Relaxed),
+    )
+}
+
+pub fn reset_counters() {
+    HANDLED.store(0, Ordering::Relaxed);
+    EXPIRED.store(0, Ordering::Relaxed);
+    NOOP.store(0, Ordering::Relaxed);
+}
+
+/// Parse ritualId and runId from a subject like "demon.ritual.v1.<ritual>.<run>.events".
+fn parse_subject(subject: &str) -> Option<(String, String)> {
+    let parts: Vec<&str> = subject.split('.').collect();
+    if parts.len() >= 6 && parts[0] == "demon" && parts[1] == "ritual" && parts[2] == "v1" {
+        Some((parts[3].to_string(), parts[4].to_string()))
+    } else {
+        None
+    }
+}
+
+/// Handle a single JetStream message; returns true if acked.
+async fn handle_message(msg: Message) -> Result<bool> {
+    let subject = msg.message.subject.clone();
+    let (ritual_id, run_id_from_subject) = match parse_subject(&subject) {
+        Some(x) => x,
+        None => {
+            warn!(%subject, "ttl_worker: unexpected subject; ack and skip");
+            let _ = msg.ack().await;
+            return Ok(true);
+        }
+    };
+
+    let v: serde_json::Value = match serde_json::from_slice(&msg.message.payload) {
+        Ok(v) => v,
+        Err(e) => {
+            warn!(error=%e, "ttl_worker: invalid JSON; ack and skip");
+            let _ = msg.ack().await;
+            return Ok(true);
+        }
+    };
+
+    let ev = v.get("event").and_then(|x| x.as_str()).unwrap_or("");
+    if ev != "timer.scheduled:v1" {
+        let _ = msg.ack().await;
+        return Ok(true);
+    }
+
+    let timer_id = match v.get("timerId").and_then(|x| x.as_str()) {
+        Some(t) => t,
+        None => {
+            warn!(%subject, "ttl_worker: timer.scheduled missing timerId; ack");
+            let _ = msg.ack().await;
+            return Ok(true);
+        }
+    };
+
+    if let Some((run_id, gate_id)) =
+        crate::rituals::approvals::parse_approval_expiry_timer_id(timer_id)
+    {
+        if run_id != run_id_from_subject {
+            warn!(%subject, run_id=%run_id, sub_run=%run_id_from_subject, "ttl_worker: runId mismatch; ack");
+            let _ = msg.ack().await;
+            return Ok(true);
+        }
+        incr(&HANDLED);
+        match crate::rituals::approvals::process_expiry_if_pending(&run_id, &ritual_id, &gate_id)
+            .await
+        {
+            Ok(did_expire) => {
+                if did_expire {
+                    incr(&EXPIRED);
+                    info!(%run_id, %gate_id, %ritual_id, "ttl_worker: expired");
+                } else {
+                    incr(&NOOP);
+                    info!(%run_id, %gate_id, %ritual_id, "ttl_worker: noop_terminal");
+                }
+                let _ = msg.ack().await;
+                return Ok(true);
+            }
+            Err(e) => {
+                error!(error=%e, %run_id, %gate_id, %ritual_id, "ttl_worker: expiry failed; not acking for retry");
+                return Ok(false);
+            }
+        }
+    } else {
+        // Not an approvals expiry timer; ignore but ack
+        let _ = msg.ack().await;
+        return Ok(true);
+    }
+}
+
+/// Resolve the ritual events stream (env override, then RITUAL_EVENTS, then DEMON_RITUAL_EVENTS).
+async fn resolve_stream(
+    js: &jetstream::Context,
+    override_name: &Option<String>,
+) -> Result<jetstream::stream::Stream> {
+    if let Some(name) = override_name.clone() {
+        return Ok(js
+            .get_or_create_stream(jetstream::stream::Config {
+                name,
+                subjects: vec!["demon.ritual.v1.>".to_string()],
+                ..Default::default()
+            })
+            .await?);
+    }
+    if let Ok(s) = js.get_stream("RITUAL_EVENTS").await {
+        return Ok(s);
+    }
+    Ok(js.get_stream("DEMON_RITUAL_EVENTS").await?)
+}
+
+pub async fn run_loop(cfg: TtlWorkerConfig) -> Result<()> {
+    info!(?cfg, "ttl_worker: starting");
+    let client = async_nats::connect(&cfg.nats_url).await?;
+    let js = jetstream::new(client);
+    let stream = resolve_stream(&js, &cfg.stream_name).await?;
+
+    let consumer = stream
+        .create_consumer(jetstream::consumer::pull::Config {
+            durable_name: Some(cfg.consumer_name.clone()),
+            filter_subject: cfg.subject_filter.clone(),
+            // explicit ack is default for pull consumer
+            ..Default::default()
+        })
+        .await?;
+
+    loop {
+        let mut batch = consumer
+            .batch()
+            .max_messages(cfg.batch)
+            .expires(std::time::Duration::from_millis(cfg.pull_timeout_ms))
+            .messages()
+            .await?;
+        while let Some(m) = batch.next().await {
+            match m {
+                Ok(m) => {
+                    let _ = handle_message(m).await?;
+                }
+                Err(e) => warn!(error=%e, "ttl_worker: message error"),
+            }
+        }
+    }
+}
+
+/// Process a single batch (useful for tests); returns (handled, expired, noop) deltas.
+pub async fn run_one_batch(cfg: TtlWorkerConfig) -> Result<(u64, u64, u64)> {
+    let client = async_nats::connect(&cfg.nats_url).await?;
+    let js = jetstream::new(client);
+    let stream = resolve_stream(&js, &cfg.stream_name).await?;
+    let consumer = stream
+        .create_consumer(jetstream::consumer::pull::Config {
+            durable_name: Some(cfg.consumer_name.clone()),
+            filter_subject: cfg.subject_filter.clone(),
+            ..Default::default()
+        })
+        .await?;
+    let (h0, e0, n0) = counters();
+    let mut batch = consumer
+        .batch()
+        .max_messages(cfg.batch)
+        .expires(std::time::Duration::from_millis(cfg.pull_timeout_ms))
+        .messages()
+        .await?;
+    while let Some(m) = batch.next().await {
+        if let Ok(m) = m {
+            let _ = handle_message(m).await?;
+        }
+    }
+    let (h1, e1, n1) = counters();
+    Ok((h1 - h0, e1 - e0, n1 - n0))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn parse_subject_happy() {
+        let s = "demon.ritual.v1.rit.run.events";
+        assert_eq!(parse_subject(s), Some(("rit".into(), "run".into())));
+    }
+    #[test]
+    fn parse_timer_id() {
+        let tid = "run-1:approval:gate-1:expiry";
+        let out = crate::rituals::approvals::parse_approval_expiry_timer_id(tid);
+        assert_eq!(out, Some(("run-1".into(), "gate-1".into())));
+    }
+}

--- a/engine/tests/ttl_worker_integration.rs
+++ b/engine/tests/ttl_worker_integration.rs
@@ -1,0 +1,86 @@
+//! Ignored by default; requires NATS dev environment.
+use chrono::{Duration, Utc};
+
+#[tokio::test]
+#[ignore]
+async fn scheduled_then_expire_once() {
+    std::env::set_var("APPROVAL_TTL_SECONDS", "2");
+    let nats_url = std::env::var("NATS_URL").unwrap_or_else(|_| "nats://127.0.0.1:4222".into());
+    let client = async_nats::connect(&nats_url).await.unwrap();
+    let js = async_nats::jetstream::new(client.clone());
+
+    // Ensure stream present
+    let _ = js
+        .get_or_create_stream(async_nats::jetstream::stream::Config {
+            name: "RITUAL_EVENTS".into(),
+            subjects: vec!["demon.ritual.v1.>".into()],
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+
+    // Seed approval.requested and timer.scheduled
+    let run = "run-ttl-worker-1";
+    let ritual = "ritual-ttl";
+    let gate = "gw";
+    let subject = format!("demon.ritual.v1.{}.{}.events", ritual, run);
+    let now = Utc::now();
+    let requested = serde_json::json!({
+        "event":"approval.requested:v1","ts":now.to_rfc3339(),
+        "tenantId":"default","runId":run,"ritualId":ritual,"gateId":gate,
+        "requester":"dev@example.com","reason":"promote"});
+    js.publish(
+        subject.clone(),
+        serde_json::to_vec(&requested).unwrap().into(),
+    )
+    .await
+    .unwrap()
+    .await
+    .unwrap();
+
+    let key = engine::rituals::approvals::expiry_key(run, gate);
+    let scheduled = serde_json::json!({
+        "event":"timer.scheduled:v1","ts":now.to_rfc3339(),
+        "runId":run,"timerId":key,"scheduledFor":(now+Duration::seconds(2)).to_rfc3339()});
+    js.publish(
+        subject.clone(),
+        serde_json::to_vec(&scheduled).unwrap().into(),
+    )
+    .await
+    .unwrap()
+    .await
+    .unwrap();
+
+    // Run one batch of worker to process messages
+    let cfg = engine::rituals::worker::ttl_worker::TtlWorkerConfig::default();
+    let _ = engine::rituals::worker::ttl_worker::run_one_batch(cfg)
+        .await
+        .unwrap();
+
+    // Read back events and ensure exactly one denial exists
+    let stream = js.get_stream("RITUAL_EVENTS").await.unwrap();
+    let cons = stream
+        .create_consumer(async_nats::jetstream::consumer::pull::Config {
+            filter_subject: subject.clone(),
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+    let mut vals = Vec::new();
+    let mut batch = cons
+        .batch()
+        .max_messages(100)
+        .expires(std::time::Duration::from_secs(1))
+        .messages()
+        .await
+        .unwrap();
+    while let Some(m) = batch.next().await {
+        let m = m.unwrap();
+        vals.push(serde_json::from_slice::<serde_json::Value>(&m.message.payload).unwrap());
+    }
+    let denies: Vec<_> = vals
+        .into_iter()
+        .filter(|v| v.get("event").and_then(|s| s.as_str()) == Some("approval.denied:v1"))
+        .collect();
+    assert_eq!(denies.len(), 1, "expected exactly one expired denial");
+}

--- a/engine/tests/ttl_worker_restart.rs
+++ b/engine/tests/ttl_worker_restart.rs
@@ -1,0 +1,90 @@
+//! Ignored by default; requires NATS and simulates restart.
+
+#[tokio::test]
+#[ignore]
+async fn restart_resume_exactly_once() {
+    let nats_url = std::env::var("NATS_URL").unwrap_or_else(|_| "nats://127.0.0.1:4222".into());
+    let client = async_nats::connect(&nats_url).await.unwrap();
+    let js = async_nats::jetstream::new(client.clone());
+
+    let _ = js
+        .get_or_create_stream(async_nats::jetstream::stream::Config {
+            name: "RITUAL_EVENTS".into(),
+            subjects: vec!["demon.ritual.v1.>".into()],
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+
+    let run = "run-ttl-worker-restart";
+    let ritual = "ritual-ttl";
+    let gate = "gw";
+    let subject = format!("demon.ritual.v1.{}.{}.events", ritual, run);
+    let now = chrono::Utc::now();
+    let requested = serde_json::json!({"event":"approval.requested:v1","ts":now.to_rfc3339(),"tenantId":"default","runId":run,"ritualId":ritual,"gateId":gate,"requester":"dev@example.com","reason":"promote"});
+    js.publish(
+        subject.clone(),
+        serde_json::to_vec(&requested).unwrap().into(),
+    )
+    .await
+    .unwrap()
+    .await
+    .unwrap();
+    let key = engine::rituals::approvals::expiry_key(run, gate);
+    let scheduled = serde_json::json!({"event":"timer.scheduled:v1","ts":now.to_rfc3339(),"runId":run,"timerId":key,"scheduledFor":(now+chrono::Duration::seconds(2)).to_rfc3339()});
+    js.publish(
+        subject.clone(),
+        serde_json::to_vec(&scheduled).unwrap().into(),
+    )
+    .await
+    .unwrap()
+    .await
+    .unwrap();
+
+    // First pass: process once but simulate crash before ack by not acking (run_loop handles acking; run_one_batch does too).
+    // To simulate restart behavior, publish the scheduled again (dup) and let idempotency ensure single denial
+    js.publish(
+        subject.clone(),
+        serde_json::to_vec(&scheduled).unwrap().into(),
+    )
+    .await
+    .unwrap()
+    .await
+    .unwrap();
+
+    let cfg = engine::rituals::worker::ttl_worker::TtlWorkerConfig::default();
+    let _ = engine::rituals::worker::ttl_worker::run_one_batch(cfg)
+        .await
+        .unwrap();
+
+    // Verify only one denial present overall
+    let stream = js.get_stream("RITUAL_EVENTS").await.unwrap();
+    let cons = stream
+        .create_consumer(async_nats::jetstream::consumer::pull::Config {
+            filter_subject: subject.clone(),
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+    let mut vals = Vec::new();
+    let mut batch = cons
+        .batch()
+        .max_messages(100)
+        .expires(std::time::Duration::from_secs(1))
+        .messages()
+        .await
+        .unwrap();
+    while let Some(m) = batch.next().await {
+        let m = m.unwrap();
+        vals.push(serde_json::from_slice::<serde_json::Value>(&m.message.payload).unwrap());
+    }
+    let denies: Vec<_> = vals
+        .into_iter()
+        .filter(|v| v.get("event").and_then(|s| s.as_str()) == Some("approval.denied:v1"))
+        .collect();
+    assert_eq!(
+        denies.len(),
+        1,
+        "expected exactly one expired denial after restart"
+    );
+}


### PR DESCRIPTION
Implements REQUEST-M2C-3: minimal durable TTL worker.

- Durable pull consumer (, default ), subject filter .
- Filters  where .
- Calls ; acks on success/no-op, leaves unacked on error.
- Binary:  (guarded by ).
- Unit helpers + ignored NATS integrations.

Review-lock: 0840265 (084026586c1bbf8784b0f525d17aa745a64222c5)