### PR TITLE
docs(changelog): add Preview Alpha kit index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## Unreleased
+
+


### PR DESCRIPTION
Docs-only. Adds a concise entry for the Preview Alpha kit index.
Traceability: preview-alpha-1 / 27e36b21136e