### PR TITLE
docs(readme): add Preview Kit link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 ![CI](https://github.com/afewell-hh/demon/actions/workflows/ci.yml/badge.svg)
+> Preview Kit: see docs/preview/alpha/README.md
+
 
 # Demon — Meta-PaaS (Milestone 0)
 


### PR DESCRIPTION
Docs-only. Adds a top-level link to the Preview Alpha kit (docs/preview/alpha/README.md).