### PR TITLE
ci: review-lock guard + CODEOWNERS + PR template

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+/bootstrapper/**   @afewell-hh
+/contracts/**      @afewell-hh
+/.github/workflows/ci.yml  @afewell-hh
+

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,22 +1,5 @@
-## Summary
-Link to REQUEST doc: <!-- e.g., docs/request/REQUEST-M1A-timer-wheel.md -->
+**Review-lock (paste HEAD SHA):** `xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx`
 
-## What changed
-- …
-
-## Checklists
-**Contracts**
-- [ ] Event/WIT changes documented and versioned (e.g., ritual.*:v1).
-- [ ] Golden fixtures updated in `contracts/fixtures/events/`.
-
-**Tests (red→green)**
-- [ ] Unit tests
-- [ ] Integration tests
-- [ ] Contract validation (schemas) or fixtures covered
-- [ ] Operate/UI views (if applicable)
-
-**Repo hygiene**
-- [ ] Small commits (≤200 LOC), clear messages
-- [ ] Docs updated
-- [ ] CI green
+- [ ] Evidence posted (build/fmt/clippy + relevant logs)
+- [ ] All required checks green
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,25 @@ on:
     branches: [ "**" ]
 
 jobs:
+  # DO NOT RENAME: Required status check for PR review-lock
+  review-lock-guard:
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' }}
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const body = pr.body || "";
+            const head = pr.head.sha;
+            const m = body.match(/[0-9a-f]{40}/i);
+            if (!m) core.setFailed("Review-lock SHA not found in PR body.");
+            else if (m[0].toLowerCase() !== head.toLowerCase())
+              core.setFailed(`Review-lock mismatch: body=${m[0].slice(0,7)} head=${head.slice(0,7)}`);
   build-test:
     runs-on: ubuntu-latest
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -296,9 +296,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64ct"
-version = "1.8.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
+checksum = "bb97d56060ee67d285efb8001fec9d2a4c710c32efd2e14b5cbb5ba71930fc2d"
 
 [[package]]
 name = "bit-set"


### PR DESCRIPTION
Adds a small review-lock guard job (required check candidate), plus CODEOWNERS for bootstrapper/contracts/CI and a minimal PR template with a review-lock field.\n\nReview-lock SHA will be updated after CI.