### PR TITLE
governance/ci: protection audit + frozen job names + CONTRIBUTING

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,18 @@
+# Contributing
+
+## Review-lock
+- Paste the current HEAD commit SHA (40 chars) into the PR body’s “Review-lock” field.
+- If the review-lock-guard fails, update the PR body to the latest HEAD SHA and it will pass on re-run.
+
+## Evidence
+- Include build/format/lint evidence and any relevant logs (e.g., verify-only JSON lines) in a PR comment.
+
+## Required checks
+- Merges require the following checks to be green:
+  - Bootstrapper bundles — verify (offline, signature ok)
+  - Bootstrapper bundles — negative verify (tamper ⇒ failed)
+  - review-lock-guard
+
+## Code Owners
+- Changes under `bootstrapper/`, `contracts/`, or `.github/workflows/ci.yml` will request a Code Owner review.
+

--- a/.github/GOVERNANCE.md
+++ b/.github/GOVERNANCE.md
@@ -1,0 +1,19 @@
+# Governance & Branch Protections
+
+## Branch rules + required checks snapshot (main)
+
+The following command snapshots branch protection for `main`:
+
+```
+gh api repos/:owner/:repo/branches/main/protection \
+  -q '{required_status_checks:.required_status_checks.contexts, enforce_admins:.enforce_admins.enabled, required_pull_request_reviews, restrictions}' | jq .
+```
+
+If your token lacks admin perms, run the command locally and paste the JSON here for posterity.
+
+Snapshot last updated: TBD
+
+Notes:
+- Required checks should include positive/negative offline bundle verify and the review-lock guard.
+- CODEOWNERS is enforced for `bootstrapper/`, `contracts/`, and CI workflow changes.
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,9 @@ on:
     branches: [ "**" ]
 
 jobs:
-  # DO NOT RENAME: Required status check for PR review-lock
+  # DO NOT RENAME: used in branch protection required checks
   review-lock-guard:
+    name: review-lock-guard
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'pull_request' }}
     permissions:
@@ -328,7 +329,9 @@ jobs:
           docker rm -f nats1 || true
           docker rm -f nats2 || true
 
+  # DO NOT RENAME: used in branch protection required checks
   bootstrapper-bundles-verify:
+    name: Bootstrapper bundles — verify (offline, signature ok)
     runs-on: ubuntu-latest
     needs: build-test
     steps:

--- a/.github/workflows/protection-audit.yml
+++ b/.github/workflows/protection-audit.yml
@@ -1,0 +1,32 @@
+name: protection-audit
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 4 * * 1'  # Mondays at 04:00 UTC
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Verify branch protection (main)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          PROT=$(gh api repos/${{ github.repository }}/branches/main/protection)
+          req_checks=$(jq -r '.required_status_checks.contexts[]?' <<<"$PROT")
+          must_have=(
+            "Bootstrapper bundles — verify (offline, signature ok)"
+            "Bootstrapper bundles — negative verify (tamper ⇒ failed)"
+            "review-lock-guard"
+          )
+          for c in "${must_have[@]}"; do
+            echo "$req_checks" | grep -Fx "$c" >/dev/null || { echo "Missing required check: $c"; exit 1; }
+          done
+          jq -e '.required_pull_request_reviews.require_code_owner_reviews == true' <<<"$PROT" >/dev/null \
+            || { echo "CODEOWNERS review not required"; exit 1; }
+          echo "Branch protection looks good."
+


### PR DESCRIPTION
- GOVERNANCE: snapshot instructions for main branch protections\n- CI: add explicit job names and DO NOT RENAME comments for required checks\n- protection-audit workflow (scheduled/dispatch) to catch drift in required checks and CODEOWNERS\n- CONTRIBUTING: review-lock + evidence + required checks + Code Owners\n\nReview-lock will be added after CI passes.