### PR TITLE
ci: add cargo-audit and cargo-deny supply chain checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,6 +192,28 @@ jobs:
         if: always()
         run: docker rm -f nats || true
 
+  cargo-audit:
+    name: Cargo audit (advisories)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Install cargo-audit
+        run: cargo install cargo-audit
+      - name: Audit
+        run: cargo audit --deny warnings
+
+  cargo-deny:
+    name: Cargo deny (licenses/bans)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install cargo-deny
+        run: curl -LsSf https://github.com/EmbarkStudios/cargo-deny/releases/latest/download/cargo-deny-$(uname -s)-$(uname -m).tar.gz \
+          | tar xz -C ~/.cargo/bin --strip-components=1 cargo-deny
+      - name: Check licenses & bans
+        run: cargo deny check --all-features
+
   bootstrapper-smoke:
     runs-on: ubuntu-latest
     needs: build-test

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,20 @@
+# deny.toml
+[advisories]
+vulnerability = "deny"   # deny known vulns
+unmaintained = "warn"
+yanked = "warn"
+notice = "warn"
+ignore = []
+
+[bans]
+multiple-versions = "warn"
+wildcards = "deny"
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+
+[licenses]
+allow = ["MIT", "Apache-2.0", "BSD-3-Clause", "BSD-2-Clause", "Unicode-DFS-2016", "ISC"]
+deny  = ["GPL-3.0", "AGPL-3.0"]
+confidence-threshold = 0.8


### PR DESCRIPTION
## Summary
- Adds Rust supply chain security checks to CI
- cargo-audit checks for known vulnerabilities
- cargo-deny validates licenses and dependency bans

## Changes
- **cargo-audit job**: Checks for security advisories, denies warnings
- **cargo-deny job**: Validates licenses against allow/deny lists  
- **deny.toml**: Configuration for allowed licenses (MIT, Apache-2.0, BSD variants) and denied licenses (GPL-3.0, AGPL-3.0)

## Test plan
- [x] `cargo build --locked --workspace` passes
- [ ] cargo-audit runs successfully in CI
- [ ] cargo-deny runs successfully in CI
- [ ] Jobs marked non-required initially (can be promoted later)

## Evidence
```bash
$ cargo build --locked --workspace
Finished \`dev\` profile [unoptimized + debuginfo] target(s) in 9.23s
```

Review-lock: 5da07ea4c1a69bbcae55f8e56f29b5e1ba0cc54f

🤖 Generated with [Claude Code](https://claude.ai/code)