### PR TITLE
chore(ci/docs): review-triage + replies-guard + contributor notes (label-gated, docs-only default)

### DIFF
--- a/.github/workflows/review-threads-guard.yml
+++ b/.github/workflows/review-threads-guard.yml
@@ -2,7 +2,7 @@ name: review-threads-guard (PR)  # DO NOT RENAME
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened, ready_for_review, labeled]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/review-threads-guard.yml
+++ b/.github/workflows/review-threads-guard.yml
@@ -1,0 +1,122 @@
+name: review-threads-guard (PR)  # DO NOT RENAME
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  guard:
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      contains(github.event.pull_request.labels.*.name, 'enforce-review-replies')
+    runs-on: ubuntu-latest
+    concurrency:
+      group: review-threads-guard-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
+    steps:
+      - name: Detect docs-only change
+        id: docsonly
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            docs:
+              - 'docs/**'
+              - '**/*.md'
+
+      - name: Skip for docs-only PRs
+        if: steps.docsonly.outputs.docs == 'true'
+        run: echo "Docs-only change; skipping guard."
+
+      - name: Check unresolved threads with no author reply
+        if: steps.docsonly.outputs.docs != 'true'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const pr = context.payload.pull_request;
+            const owner = context.repo.owner;
+            const repo  = context.repo.repo;
+            const number = pr.number;
+
+            // Fetch PR author and all review threads (paginated)
+            const query = `
+              query Threads($owner:String!, $repo:String!, $number:Int!, $after:String) {
+                repository(owner:$owner, name:$repo) {
+                  pullRequest(number:$number) {
+                    author { login }
+                    reviewThreads(first: 100, after: $after) {
+                      nodes {
+                        isResolved
+                        comments(first: 100) {
+                          nodes {
+                            author { login }
+                            url
+                            createdAt
+                          }
+                        }
+                      }
+                      pageInfo { hasNextPage endCursor }
+                    }
+                  }
+                }
+              }`;
+
+            let after = null;
+            let threads = [];
+            let authorLogin = null;
+
+            do {
+              const res = await github.graphql(query, { owner, repo, number, after });
+              const prData = res.repository.pullRequest;
+              authorLogin = authorLogin ?? (prData.author && prData.author.login);
+              const page = prData.reviewThreads;
+              threads.push(...page.nodes);
+              after = page.pageInfo.hasNextPage ? page.pageInfo.endCursor : null;
+            } while (after);
+
+            // Evaluate unresolved + no author reply
+            let offending = [];
+            for (const t of threads) {
+              if (t.isResolved) continue;
+              const hasAuthorReply = t.comments.nodes.some(c => c.author?.login === authorLogin);
+              if (!hasAuthorReply) {
+                // Use the first comment URL as a deep link for action
+                const firstUrl = t.comments.nodes[0]?.url || '';
+                offending.push(firstUrl);
+              }
+            }
+
+            core.info(`Found ${threads.length} threads; offending unresolved-no-reply: ${offending.length}`);
+            if (offending.length > 0) {
+              core.setFailed(
+                [
+                  `Unresolved review threads without author reply: ${offending.length}`,
+                  `Please respond on each thread (Fixed/Clarified/Won’t fix) and/or resolve.`,
+                  `Links:\n- ${offending.join('\n- ')}`
+                ].join('\n')
+              );
+            }
+
+      - name: Comment on failure with links
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const body = `### 🔴 Review threads guard failed
+            Please reply to each unresolved thread (Fixed/Clarified/Won’t fix) and/or resolve.
+            See failing job logs for deep links.`;
+            const {owner, repo} = context.repo;
+            const issue_number = context.payload.pull_request.number;
+            const existing = await github.rest.issues.listComments({owner, repo, issue_number});
+            const prev = existing.data.find(c => c.user.type === 'Bot' && c.body?.includes('Review threads guard failed'));
+            if (prev) {
+              await github.rest.issues.updateComment({owner, repo, comment_id: prev.id, body});
+            } else {
+              await github.rest.issues.createComment({owner, repo, issue_number, body});
+            }

--- a/.github/workflows/review-triage-comment.yml
+++ b/.github/workflows/review-triage-comment.yml
@@ -1,0 +1,104 @@
+name: review-triage (PR comment)
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review, labeled]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  comment:
+    # Gate to PRs that have the label "triage-comment" to avoid noise.
+    if: >
+      github.event.pull_request.draft == false &&
+      (
+        contains(join(fromJSON(toJSON(github.event.pull_request.labels)).*.name, ','), 'triage-comment') ||
+        github.event_name == 'workflow_dispatch'
+      )
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    concurrency:
+      group: review-triage-comment-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Generate repo triage report
+        run: |
+          chmod +x ./audit-pr-triage-md.sh
+          ./audit-pr-triage-md.sh
+
+      - name: Extract current PR section
+        id: extract
+        run: |
+          PR=${{ github.event.pull_request.number }}
+          SRC="$(ls -t pr-review-triage-*.md | head -n1)"
+          OUT="pr-review-triage-pr-${PR}.md"
+          awk -v pr="## PR #"$PR":" '
+            BEGIN { found=0 }
+            found==0 && index($0, pr)==1 { found=1; print; next }
+            found==1 {
+              if ($0 ~ /^## PR #/ && index($0, pr)!=1) exit
+              print
+            }
+          ' "$SRC" > "$OUT" || true
+          # Fallback to entire file if section not found
+          test -s "$OUT" || cp "$SRC" "$OUT"
+          echo "file=$OUT" >> "$GITHUB_OUTPUT"
+
+      - name: Post or update sticky comment
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const pr = context.payload.pull_request.number;
+            const anchor = `<!-- review-triage:pr-${pr}:do-not-edit -->`;
+            const fs = require('fs');
+            const bodyMd = fs.readFileSync(process.env.FILE, 'utf8');
+            const header = `### 🧭 Review triage\n${anchor}\n`;
+            const footer = [
+              '',
+              '> _This is a generated snapshot from `audit-pr-triage-md.sh`. ' +
+              'Resolve threads or reply (Fixed/Clarified/Won’t fix) before merging._'
+            ].join('\n');
+            const newBody = header + bodyMd + '\n' + footer;
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr,
+              per_page: 100
+            });
+
+            const prior = comments.find(c =>
+              c.user.type === 'Bot' && c.body && c.body.includes(anchor)
+            );
+
+            if (prior) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: prior.id,
+                body: newBody
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr,
+                body: newBody
+              });
+            }
+        env:
+          FILE: ${{ steps.extract.outputs.file }}
+
+      - name: Upload triage artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr-${{ github.event.pull_request.number }}-review-triage
+          path: |
+            pr-review-triage-*.md

--- a/.github/workflows/review-triage.yml
+++ b/.github/workflows/review-triage.yml
@@ -1,0 +1,48 @@
+name: review-triage (PR)
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  triage:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}   # used by gh inside the script
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Generate repo triage report (last 30 PRs)
+        run: |
+          chmod +x ./audit-pr-triage-md.sh
+          ./audit-pr-triage-md.sh
+
+      # Optional: extract a per-PR mini report section for this PR
+      - name: Extract current PR section
+        run: |
+          PR=${{ github.event.pull_request.number }}
+          SRC="$(ls -t pr-review-triage-*.md | head -n1)"
+          awk -v pr="## PR #"$PR":" '
+            BEGIN { found=0 }
+            found==0 && index($0, pr)==1 { found=1; print; next }
+            found==1 {
+              if ($0 ~ /^## PR #/ && index($0, pr)!=1) exit
+              print
+            }
+          ' "$SRC" > "pr-review-triage-pr-${PR}.md" || true
+          test -s "pr-review-triage-pr-${PR}.md" || cp "$SRC" "pr-review-triage-pr-${PR}.md"
+
+      - name: Upload triage artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr-${{ github.event.pull_request.number }}-review-triage
+          path: |
+            pr-review-triage-*.md
+          if-no-files-found: error
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,14 @@
+# Contributing
+
+This repo uses two labels to keep review feedback visible and ensure responsiveness without blocking healthy discussion.
+
+- `triage-comment` — Posts/updates a sticky triage summary on the PR with deep links to unresolved review threads. Visibility only; does not affect status checks.
+- `enforce-review-replies` — Runs the `review-threads-guard (PR)` check. The PR fails if any unresolved review thread has no reply from the PR author. Pairs well with GitHub’s “Require conversation resolution”.
+
+Handy commands
+- `make audit-triage` — Generate a repo triage Markdown report for the last N PRs (`COUNT=60 make audit-triage`).
+- `make audit-triage-issue` — Generate today’s report and open an issue with it attached.
+
+Notes
+- Both review triage workflows can also be triggered manually via “Run workflow”.
+- Administrators are encouraged to enable “Require conversation resolution” (include administrators) on `main` and mark `review-threads-guard (PR) / guard` as required once stable.

--- a/audit-pr-threads.sh
+++ b/audit-pr-threads.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Audit unresolved PR review threads (and no-reply threads)
+# Usage:
+#   bash audit-pr-threads.sh            # scans last 30 PRs (default)
+#   COUNT=100 bash audit-pr-threads.sh  # scan last 100 PRs
+#
+# Requirements: gh (authenticated), jq
+
+OWNER=${OWNER:-afewell-hh}
+REPO=${REPO:-Demon}
+COUNT=${COUNT:-30}
+
+read -r -d '' Q <<'GRAPHQL' || true
+query($owner:String!, $name:String!, $n:Int!) {
+  repository(owner:$owner, name:$name){
+    pullRequests(last:$n, states:[OPEN, MERGED, CLOSED], orderBy:{field:UPDATED_AT, direction:DESC}) {
+      nodes {
+        number title state mergedAt url author { login }
+        reviewThreads(first:100) {
+          nodes {
+            isResolved
+            isOutdated
+            comments(first:50) {
+              totalCount
+              nodes {
+                author { login }
+                url
+                publishedAt
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+GRAPHQL
+
+JSON=$(gh api graphql -f owner=$OWNER -f name=$REPO -F n=$COUNT -f query="$Q")
+
+echo "PR,State,UnresolvedThreads,UnresolvedNoReplyThreads,URL"
+jq -r '
+  .data.repository.pullRequests.nodes[]
+  | . as $pr
+  | ($pr.reviewThreads.nodes // []) as $threads
+  | ($threads
+      | map(select(.isResolved==false))
+    ) as $unresolved
+  | ($unresolved
+      | map(
+          {noReply:
+            ( ( .comments.totalCount // 0 ) <= 1
+              or ( .comments.nodes // [] | map(.author.login) | length==1 )
+            ),
+           firstUrl: ( .comments.nodes[0].url // $pr.url )
+          }
+        )
+    ) as $marks
+  | [$pr.number,
+     $pr.state,
+     ($unresolved | length),
+     ($marks | map(select(.noReply==true)) | length),
+     $pr.url
+    ]
+  | @csv
+' <<<"$JSON" | sed '1!b;s/\"//g'

--- a/audit-pr-triage-md.sh
+++ b/audit-pr-triage-md.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# deps
+for bin in gh jq; do
+  command -v "$bin" >/dev/null || { echo "missing dependency: $bin"; exit 1; }
+done
+
+OWNER=${OWNER:-afewell-hh}
+REPO=${REPO:-Demon}
+COUNT=${COUNT:-30}   # scan last N PRs
+OUTDIR=${OUTDIR:-.}
+STAMP=$(date -u +%F)
+OUT="${OUTDIR}/pr-review-triage-${STAMP}.md"
+
+read -r -d '' Q <<'GRAPHQL' || true
+query($owner:String!, $name:String!, $n:Int!) {
+  repository(owner:$owner, name:$name){
+    pullRequests(last:$n, states:[OPEN, MERGED, CLOSED], orderBy:{field:UPDATED_AT, direction:DESC}) {
+      nodes {
+        number title state mergedAt url author { login }
+        reviewThreads(first:100) {
+          nodes {
+            isResolved
+            isOutdated
+            comments(first:50) {
+              totalCount
+              nodes {
+                author { login }
+                url
+                bodyText
+                publishedAt
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+GRAPHQL
+
+JSON=$(gh api graphql -f owner="$OWNER" -f name="$REPO" -F n="$COUNT" -f query="$Q")
+
+# Build Markdown
+{
+  echo "# Review Triage Report — last ${COUNT} PRs"
+  echo
+  echo "_Generated: ${STAMP} UTC — repo: ${OWNER}/${REPO}_"
+  echo
+  jq -r '
+    def trunc(s; n):
+      if s == null then "" else
+        if (s|length) > n then (s[0:n] + "…") else s end
+      end;
+
+    .data.repository.pullRequests.nodes[]
+    | . as $pr
+    | ($pr.reviewThreads.nodes // []) as $threads
+    | ($threads | map(select(.isResolved==false))) as $unres
+    | ($unres
+        | map({
+            first: (.comments.nodes[0]?),
+            last:  (.comments.nodes[-1]?),
+            total: (.comments.totalCount // 0),
+            authorPresent: ((.comments.nodes // []) | any(.author.login == $pr.author.login)),
+            firstUrl: (.comments.nodes[0]?.url),
+            firstText: trunc(.comments.nodes[0]?.bodyText; 200),
+            firstAuthor: (.comments.nodes[0]?.author.login),
+            lastAuthor:  (.comments.nodes[-1]?.author.login),
+            lastUrl: (.comments.nodes[-1]?.url)
+          })
+      ) as $details
+    | ($details | map(select(.authorPresent|not)) | length) as $noReplyCount
+    |
+    "## PR #" + ($pr.number|tostring) + ": " + $pr.title,
+    "- URL: " + $pr.url,
+    "- Author: @" + $pr.author.login + " | State: " + $pr.state + (if $pr.mergedAt then " | MergedAt: " + $pr.mergedAt else "" end),
+    "- Unresolved threads: " + (($unres|length)|tostring) + " | No-reply: " + ($noReplyCount|tostring),
+    ( if ($unres|length) == 0
+      then "\n"
+      else
+        ( $details[]
+          | "* " +
+            (if .authorPresent then "" else "**NO-REPLY** · " end) +
+            "[thread](" + (.firstUrl // $pr.url) + ") · " +
+            (if .total then (.total|tostring) + " comment(s) · " else "" end) +
+            "first by @" + ((.firstAuthor // "n/a")) +
+            (if .lastAuthor and .lastUrl and (.lastUrl != .firstUrl)
+               then " · last by @" + .lastAuthor
+               else ""
+             end) +
+            "\n  > " + ((.firstText // "")|gsub("\n"; " ") )
+        )
+      end
+    ),
+    ""  # spacer
+  ' <<<"$JSON"
+  cat <<'TEMPLATES'
+
+---
+
+## Quick reply snippets
+
+- **Fixed:** _“Addressed in `<short-sha>`; please re-review.”_
+- **Clarified:** _“Added explanation in docs/comments at `<link>`.”_
+- **Won’t fix (reason):** _“Won’t fix because `<reason>`; tracking in #<issue>.”_
+
+> Close each thread after replying (or push a fix) to keep the audit trail clean.
+
+TEMPLATES
+} > "$OUT"
+
+echo "wrote $OUT"
+


### PR DESCRIPTION
## Summary
Codifies the review-triage/reporting workflow, the label-gated "unresolved + no-reply" guard, and contributor guidance so review feedback is visible and addressed before merge.

## What changed
- Workflows
  - `.github/workflows/review-triage.yml` — builds repo-wide and PR-scoped triage reports; uploads as artifacts.
  - `.github/workflows/review-triage-comment.yml` — **gated on `triage-comment`**; posts/updates a single sticky PR comment.
  - `.github/workflows/review-threads-guard.yml` — **gated on `enforce-review-replies`**; fails only when a PR has *unresolved* review threads **without** an author reply; docs-only PRs auto-skip; posts a concise sticky failure comment.
- Tooling
  - `audit-pr-threads.sh` — CSV audit of unresolved/no-reply threads.
  - `audit-pr-triage-md.sh` — Markdown triage with deep links + reply templates.
  - `Makefile` — `make audit-triage` and `make audit-triage-issue`.
- Docs
  - `CONTRIBUTING.md` — explains labels:
    - `triage-comment` → visibility only (sticky triage summary).
    - `enforce-review-replies` → enforcement (guard job).
  - (Governance notes already in place; no changes here.)

## Why
- Ensures comments get explicit replies before merge.
- Keeps noise low (labels control visibility/enforcement).
- Gives maintainers fast triage artifacts and deep links.

## Definition of Ready (DoR)
- [x] Workflows reference frozen job names with **“DO NOT RENAME”** notes.
- [x] Label gates: `triage-comment` and `enforce-review-replies`.
- [x] Docs-only path skip in the guard.

## Definition of Done (DoD)
- [ ] PR body **Review-lock** is set to HEAD SHA: `573561c5034dd631404fef7a329b67a17da5e5b0`
- [ ] CI green on: triage (PR), triage-comment (when labeled), guard (when labeled).
- [ ] Evidence comment posted (see below).
- [ ] Optional (after soak): mark **review-threads-guard (PR) / guard** as a required check.

## Evidence checklist to comment on this PR
- `make audit-triage` output (or `COUNT=60 make audit-triage`)
- A run of **review-triage (PR)** showing artifacts uploaded
- Label `triage-comment` on any PR → sticky comment updates
- Label `enforce-review-replies` on a PR with an unresolved/no-reply thread → guard fails + sticky comment appears; reply (but don’t resolve) → guard passes; resolve → all green

## Rollout / safeguards
- Default state is non-enforcing; guard runs only when labeled.
- Docs-only PRs auto-skip guard.
- Rollback: remove labels; delete the guard workflow; no stateful data.

## Change log (proposed)
- docs/ci: review triage & replies guard (label-gated), contributor notes
