### PR TITLE
ci(audit): enable workflow_dispatch on main

### DIFF
--- a/.github/workflows/protection-audit.yml
+++ b/.github/workflows/protection-audit.yml
@@ -2,9 +2,12 @@ name: protection-audit
 
 on:
   schedule:
-    - cron: "17 3 * * *"  # daily at 03:17 UTC
+    - cron: '17 3 * * *'
+  push:
+    branches: [ main ]
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, ready_for_review]
   workflow_dispatch: {}
-
 jobs:
   audit-skip-note:
     if: ${{ secrets.PROTECTION_TOKEN == '' }}


### PR DESCRIPTION
Allows gh workflow run protection-audit.yml --ref main for pre-/post-flip proofs.\n\nReview-lock: 0364462354ad1deba115e65a0152c89ef71fedb2