### PR TITLE
docs: add M0-3 quotas note to README Quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ The echo capsule prints `Hello from Demon!`
 
 A JSON event for `ritual.completed:v1` is printed to stdout.
 
+**Note**: M0-3 includes per-capability quotas with policy decisions. Default quotas allow reasonable development usage without configuration.
+
 ## Layout
 
 - `engine/` — minimal ritual interpreter (M0).


### PR DESCRIPTION
Add brief note about M0-3 per-capability quotas and default configuration to the README Quickstart section.

Part of M0-3 stabilization work.

Review-lock: 3a3e6be9f8c9b0b1c2d5e8f7a4b5c6d7e8f9a0b1