### PR TITLE
ci: fix Project Backfill permissions (unblock scheduling)

### DIFF
--- a/.github/workflows/project-backfill.yml
+++ b/.github/workflows/project-backfill.yml
@@ -12,10 +12,10 @@ jobs:
   backfill:
     runs-on: ubuntu-latest
     if: ${{ secrets.ADMINTOKEN_DEMON_AFEWELLHH != '' }}
+    # Use a minimal default GITHUB_TOKEN; all privileged calls go through GH_TOKEN (PAT)
     permissions:
       contents: read
       issues: read
-      repository-projects: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Fix: Project Backfill workflow fails to schedule due to deprecated permission key

- Remove deprecated `repository-projects: write` job permission.
- Keep minimal `permissions` (contents, issues) since privileged calls use `GH_TOKEN` (ADMINTOKEN_DEMON_AFEWELLHH).

Why
- The last runs failed before any job started, indicating a workflow-level parse/validation error.
- GitHub no longer accepts the `repository-projects` permission. This causes the workflow to fail validation.

Validation
- action parsing OK via `act -n -W .github/workflows/project-backfill.yml -l`.
- Will re-dispatch on `main` after merge with: issue_numbers `56 57 58 59 60 61 62 63 83 84 85 86 87 88 89` and confirm the board backfill.

Review-lock: %s1d14cf8629718038c75ca87dcb09e6a3a90b550d