### PR TITLE
ci: fix Project Backfill dispatch scheduling

### DIFF
--- a/.github/workflows/project-backfill.yml
+++ b/.github/workflows/project-backfill.yml
@@ -11,12 +11,19 @@ on:
 jobs:
   backfill:
     runs-on: ubuntu-latest
-    if: ${{ secrets.ADMINTOKEN_DEMON_AFEWELLHH != '' }}
     # Use a minimal default GITHUB_TOKEN; all privileged calls go through GH_TOKEN (PAT)
     permissions:
       contents: read
       issues: read
     steps:
+      - name: Check for required admin token
+        run: |
+          if [ -z "${{ secrets.ADMINTOKEN_DEMON_AFEWELLHH }}" ]; then
+            echo "::error::ADMINTOKEN_DEMON_AFEWELLHH secret is not configured. This workflow requires admin privileges to manage project items."
+            exit 1
+          fi
+          echo "Admin token is configured, proceeding with backfill"
+
       - name: Checkout
         uses: actions/checkout@v4
 

--- a/operate-ui/tests/filters_spec.rs
+++ b/operate-ui/tests/filters_spec.rs
@@ -45,4 +45,3 @@ async fn list_runs_api_rejects_invalid_limit() {
         assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
     }
 }
-


### PR DESCRIPTION
## Summary
Replace job-level `if:` guard with explicit step-level secret check to allow workflow_dispatch runs to schedule normally.

## Problem
The job-level guard `if: ${{ secrets.ADMINTOKEN_DEMON_AFEWELLHH != '' }}` was preventing the workflow from starting when triggered from the Actions UI, making it impossible to run the backfill manually.

## Solution
- Remove job-level `if:` condition that blocks scheduling
- Add explicit step to check if the admin token secret is configured
- Fail with clear `::error::` message if the secret is missing
- Workflow can now schedule but still requires proper authorization

## Testing
- Validated YAML syntax with Python's yaml module
- Will test workflow_dispatch after merge to confirm it schedules properly

Review-lock: cb83d52807dd5aa6dc329e55d9440e97fadf0961