### PR TITLE
ci: use PROJECT_ADMIN_TOKEN for Project Backfill

### DIFF
--- a/.github/workflows/project-backfill.yml
+++ b/.github/workflows/project-backfill.yml
@@ -11,18 +11,31 @@ on:
 jobs:
   backfill:
     runs-on: ubuntu-latest
-    if: ${{ secrets.ADMINTOKEN_DEMON_AFEWELLHH != '' }}
     # Use a minimal default GITHUB_TOKEN; all privileged calls go through GH_TOKEN (PAT)
     permissions:
       contents: read
       issues: read
     steps:
+      - name: Check for required admin token
+        run: |
+          if [ -n "${{ secrets.PROJECT_ADMIN_TOKEN }}" ]; then
+            echo "Using PROJECT_ADMIN_TOKEN for project operations"
+            echo "token_source=PROJECT_ADMIN_TOKEN" >> "$GITHUB_OUTPUT"
+          elif [ -n "${{ secrets.ADMINTOKEN_DEMON_AFEWELLHH }}" ]; then
+            echo "Falling back to ADMINTOKEN_DEMON_AFEWELLHH for project operations"
+            echo "token_source=ADMINTOKEN_DEMON_AFEWELLHH" >> "$GITHUB_OUTPUT"
+          else
+            echo "::error::No admin token configured. This workflow requires PROJECT_ADMIN_TOKEN or ADMINTOKEN_DEMON_AFEWELLHH secret for project management."
+            exit 1
+          fi
+        id: token-check
+
       - name: Checkout
         uses: actions/checkout@v4
 
       - name: Backfill issues to project
         env:
-          GH_TOKEN: ${{ secrets.ADMINTOKEN_DEMON_AFEWELLHH }}
+          GH_TOKEN: ${{ steps.token-check.outputs.token_source == 'PROJECT_ADMIN_TOKEN' && secrets.PROJECT_ADMIN_TOKEN || secrets.ADMINTOKEN_DEMON_AFEWELLHH }}
         run: |
           set -euo pipefail
 


### PR DESCRIPTION
## Summary
Switch Project Backfill workflow to use the new PROJECT_ADMIN_TOKEN secret to resolve "Resource not accessible by personal access token" errors when managing ProjectV2 items.

## Changes
- Remove job-level `if:` condition to allow workflow_dispatch scheduling
- Add step-level token selection that prioritizes PROJECT_ADMIN_TOKEN with fallback to ADMINTOKEN_DEMON_AFEWELLHH
- Clear logging shows which token is being used for transparency
- Clear error message when no admin token is configured

## Context
The previous fine-grained ADMINTOKEN_DEMON_AFEWELLHH token couldn't access user-owned Project V2 items. The new PROJECT_ADMIN_TOKEN contains a classic GitHub token with full project scope.

## Testing
- [x] YAML syntax validated with Python yaml.safe_load
- [x] Workflow scheduling fix confirmed from previous PR
- [x] New PROJECT_ADMIN_TOKEN secret is already provisioned

Review-lock: deb38bd6e7ee6c4e0baa53bb8b90c34a0b29e46e

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>