### PR TITLE
docs: document PROJECT_ADMIN_TOKEN secret

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,7 +90,8 @@
 ## CI, Tokens & Secrets
 - **Local GH auth**: `gh` must be authenticated as `afewell-hh`. `.env` may export `GH_TOKEN` for CLI use (do not commit).
 - **Admin/tokenized calls in CI**:
-  - Use `PROTECTION_TOKEN` (or `ADMINTOKEN_DEMON_AFEWELLHH`) **only** in workflows that gate admin endpoints; guard with `if: env.PROTECTION_TOKEN != ''` and request minimal `permissions`.
+  - Use `PROJECT_ADMIN_TOKEN` for Project V2 automation (Project Backfill workflow); falls back to `ADMINTOKEN_DEMON_AFEWELLHH` if absent.
+  - Use `PROTECTION_TOKEN` **only** in workflows that gate admin endpoints; guard with `if: env.PROTECTION_TOKEN != ''` and request minimal `permissions`.
   - Never print tokens; never echo secrets to logs.
 - **Cargo/security**:
   - `cargo-deny` step may be `continue-on-error: true` (non-protected signal).

--- a/docs/process/PM_REBOOT_PLAYBOOK.md
+++ b/docs/process/PM_REBOOT_PLAYBOOK.md
@@ -26,7 +26,8 @@ Purpose: enable a fresh PM session (new context window) to regain full mastery q
   - `REVIEWER_TOKEN` — collaborator context (fallback only when necessary).
   - `PROTECTION_TOKEN` — admin read‑only for audits.
 - Actions Secrets (never print): repo settings
-  - `ADMINTOKEN_DEMON_AFEWELLHH` — fine‑grained for Project V2 automation.
+  - `PROJECT_ADMIN_TOKEN` — primary secret for project automation/backfill workflows.
+  - `ADMINTOKEN_DEMON_AFEWELLHH` — fallback for Project V2 automation (used only if PROJECT_ADMIN_TOKEN absent).
   - `PROTECTION_TOKEN` — protection audit workflow.
   - `REVIEWER_TOKEN` — collaborator automation if needed.
 - Pattern: `export GH_TOKEN="$GITHUB_TOKEN"` for CLI; never echo tokens.
@@ -42,7 +43,7 @@ Purpose: enable a fresh PM session (new context window) to regain full mastery q
 - Project board (V2): https://github.com/users/afewell-hh/projects/1 (configure views Backlog/Area/Target Release).
 - Automation:
   - Auto‑add: .github/workflows/project-auto-add.yml:1 — adds `story` issues, sets defaults (handles single‑select/text).
-  - Backfill: .github/workflows/project-backfill.yml:1 — manual `workflow_dispatch` with `issue_numbers`.
+  - Backfill: .github/workflows/project-backfill.yml:1 — manual `workflow_dispatch` with `issue_numbers`; now schedules normally after recent fixes.
 - GraphQL quick‑refs (Project V2): see docs/process/MVP.md:1 and .github/GOVERNANCE.md:29 for API usage patterns.
 
 ## 6) First Hour In A New Session (Checklist)


### PR DESCRIPTION
## Summary
Document the new PROJECT_ADMIN_TOKEN secret in permanent references for future sessions. Updates both the PM Reboot Playbook and AGENTS.md to reflect the primary/fallback token usage pattern.

## Changes
- Add PROJECT_ADMIN_TOKEN as primary secret for project automation/backfill workflows
- Note ADMINTOKEN_DEMON_AFEWELLHH as fallback (used only if PROJECT_ADMIN_TOKEN absent)
- Document that Project Backfill workflow now schedules normally after recent fixes
- Keep messaging concise and consistent with existing style

## Files Updated
- `docs/process/PM_REBOOT_PLAYBOOK.md` Section 3: Tokens & Secrets
- `AGENTS.md` CI, Tokens & Secrets section

Fixes #101
Epic: MVP-E5 (CI/Protections Simplification)

Review-lock: fe113ffb1719f360c001f5fca354e436581df1b9
