### PR TITLE
feat(registry): add envelope validation endpoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -195,6 +195,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "auto-future"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c1e7e457ea78e524f48639f551fd79703ac3f2237f5ecccdf4708f8a75ad373"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -265,6 +271,35 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "axum-test"
+version = "14.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "167294800740b4b6bc7bfbccbf3a1d50a6c6e097342580ec4c11d1672e456292"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "auto-future",
+ "axum",
+ "bytes",
+ "cookie",
+ "http 1.3.1",
+ "http-body-util",
+ "hyper 1.7.0",
+ "hyper-util",
+ "mime",
+ "pretty_assertions",
+ "reserve-port",
+ "rust-multipart-rfc7578_2",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "smallvec",
+ "tokio",
+ "tower 0.4.13",
+ "url",
 ]
 
 [[package]]
@@ -565,6 +600,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "cookie"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
+dependencies = [
+ "time",
+ "version_check",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -690,6 +735,8 @@ dependencies = [
  "clap",
  "engine",
  "envelope",
+ "predicates",
+ "reqwest 0.11.27",
  "serde",
  "serde_json",
  "tempfile",
@@ -724,6 +771,12 @@ name = "deunicode"
 version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abd57806937c9cc163efc8ea3910e00a62e2aeb0b8119f1793a978088f8f6b04"
+
+[[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "difflib"
@@ -1932,9 +1985,11 @@ dependencies = [
  "async-nats",
  "async-stream",
  "axum",
+ "axum-test",
  "chrono",
  "futures-util",
  "reqwest 0.11.27",
+ "runtime",
  "serde",
  "serde_json",
  "tempfile",
@@ -2178,6 +2233,16 @@ checksum = "72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c"
 dependencies = [
  "predicates-core",
  "termtree",
+]
+
+[[package]]
+name = "pretty_assertions"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
+dependencies = [
+ "diff",
+ "yansi",
 ]
 
 [[package]]
@@ -2471,6 +2536,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "reserve-port"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21918d6644020c6f6ef1993242989bf6d4952d2e025617744f184c02df51c356"
+dependencies = [
+ "thiserror 2.0.16",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2490,7 +2564,27 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "capsules_echo",
+ "envelope",
+ "once_cell",
+ "serde",
  "serde_json",
+ "tracing",
+]
+
+[[package]]
+name = "rust-multipart-rfc7578_2"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03b748410c0afdef2ebbe3685a6a862e2ee937127cdaae623336a459451c8d57"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http 0.2.12",
+ "mime",
+ "mime_guess",
+ "rand 0.8.5",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -3243,6 +3337,11 @@ version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
 dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project",
+ "pin-project-lite",
+ "tokio",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -4033,6 +4132,12 @@ name = "writeable"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,3 +34,4 @@ tokio = { version = "1", features = ["full"] }
 jsonschema = "0.18"
 futures-util = "0.3"
 base64ct = "=1.7.1"
+once_cell = "1.19"

--- a/demonctl/Cargo.toml
+++ b/demonctl/Cargo.toml
@@ -16,7 +16,9 @@ bootstrapper-demonctl = { path = "../bootstrapper/demonctl" }
 tokio = { workspace = true }
 envelope = { path = "../crates/envelope" }
 serde = { workspace = true }
+reqwest = { version = "0.11", default-features = false, features = ["json", "rustls-tls"] }
 
 [dev-dependencies]
 assert_cmd = "2.0"
 tempfile = "3.0"
+predicates = "3.0"

--- a/demonctl/tests/contracts_validate_spec.rs
+++ b/demonctl/tests/contracts_validate_spec.rs
@@ -1,5 +1,5 @@
 use assert_cmd::Command;
-use predicates::prelude::*;
+use predicates;
 use serde_json::json;
 use std::fs;
 use tempfile::TempDir;

--- a/demonctl/tests/contracts_validate_spec.rs
+++ b/demonctl/tests/contracts_validate_spec.rs
@@ -1,4 +1,5 @@
 use assert_cmd::Command;
+use predicates::prelude::*;
 use serde_json::json;
 use std::fs;
 use tempfile::TempDir;
@@ -18,7 +19,7 @@ fn given_valid_envelope_file_when_validate_then_exits_successfully() {
     fs::write(&file_path, serde_json::to_string(&envelope).unwrap()).unwrap();
 
     let mut cmd = Command::cargo_bin("demonctl").unwrap();
-    cmd.args(&[
+    cmd.args([
         "contracts",
         "validate-envelope",
         file_path.to_str().unwrap(),
@@ -40,7 +41,7 @@ fn given_invalid_envelope_file_when_validate_then_exits_with_error() {
     fs::write(&file_path, serde_json::to_string(&envelope).unwrap()).unwrap();
 
     let mut cmd = Command::cargo_bin("demonctl").unwrap();
-    cmd.args(&[
+    cmd.args([
         "contracts",
         "validate-envelope",
         file_path.to_str().unwrap(),
@@ -60,7 +61,7 @@ fn given_valid_envelope_on_stdin_when_validate_then_exits_successfully() {
     });
 
     let mut cmd = Command::cargo_bin("demonctl").unwrap();
-    cmd.args(&["contracts", "validate-envelope", "--stdin"])
+    cmd.args(["contracts", "validate-envelope", "--stdin"])
         .write_stdin(serde_json::to_string(&envelope).unwrap())
         .assert()
         .success()
@@ -83,7 +84,7 @@ fn given_invalid_envelope_on_stdin_when_validate_then_exits_with_error() {
     });
 
     let mut cmd = Command::cargo_bin("demonctl").unwrap();
-    cmd.args(&["contracts", "validate-envelope", "--stdin"])
+    cmd.args(["contracts", "validate-envelope", "--stdin"])
         .write_stdin(serde_json::to_string(&envelope).unwrap())
         .assert()
         .failure()
@@ -120,7 +121,7 @@ fn given_directory_with_result_files_when_bulk_validate_then_processes_all() {
     .unwrap();
 
     let mut cmd = Command::cargo_bin("demonctl").unwrap();
-    cmd.args(&[
+    cmd.args([
         "contracts",
         "validate-envelope",
         "--bulk",
@@ -134,7 +135,7 @@ fn given_directory_with_result_files_when_bulk_validate_then_processes_all() {
 #[test]
 fn given_no_input_specified_when_validate_then_exits_with_error() {
     let mut cmd = Command::cargo_bin("demonctl").unwrap();
-    cmd.args(&["contracts", "validate-envelope"])
+    cmd.args(["contracts", "validate-envelope"])
         .assert()
         .failure()
         .stderr(predicates::str::contains("Must specify"));

--- a/demonctl/tests/contracts_validate_spec.rs
+++ b/demonctl/tests/contracts_validate_spec.rs
@@ -1,5 +1,5 @@
 use assert_cmd::Command;
-use predicates;
+use predicates::str;
 use serde_json::json;
 use std::fs;
 use tempfile::TempDir;
@@ -26,7 +26,7 @@ fn given_valid_envelope_file_when_validate_then_exits_successfully() {
     ])
     .assert()
     .success()
-    .stdout(predicates::str::contains("✓ Valid envelope"));
+    .stdout(str::contains("✓ Valid envelope"));
 }
 
 #[test]
@@ -48,7 +48,7 @@ fn given_invalid_envelope_file_when_validate_then_exits_with_error() {
     ])
     .assert()
     .failure()
-    .stderr(predicates::str::contains("✗ Invalid envelope"));
+    .stderr(str::contains("✗ Invalid envelope"));
 }
 
 #[test]
@@ -65,7 +65,7 @@ fn given_valid_envelope_on_stdin_when_validate_then_exits_successfully() {
         .write_stdin(serde_json::to_string(&envelope).unwrap())
         .assert()
         .success()
-        .stdout(predicates::str::contains("✓ Valid envelope"));
+        .stdout(str::contains("✓ Valid envelope"));
 }
 
 #[test]
@@ -88,7 +88,7 @@ fn given_invalid_envelope_on_stdin_when_validate_then_exits_with_error() {
         .write_stdin(serde_json::to_string(&envelope).unwrap())
         .assert()
         .failure()
-        .stderr(predicates::str::contains("✗ Invalid envelope"));
+        .stderr(str::contains("✗ Invalid envelope"));
 }
 
 #[test]
@@ -129,7 +129,7 @@ fn given_directory_with_result_files_when_bulk_validate_then_processes_all() {
     ])
     .assert()
     .success()
-    .stdout(predicates::str::contains("Valid: 1"));
+    .stdout(str::contains("Valid: 1"));
 }
 
 #[test]
@@ -138,5 +138,5 @@ fn given_no_input_specified_when_validate_then_exits_with_error() {
     cmd.args(["contracts", "validate-envelope"])
         .assert()
         .failure()
-        .stderr(predicates::str::contains("Must specify"));
+        .stderr(str::contains("Must specify"));
 }

--- a/demonctl/tests/contracts_validate_spec.rs
+++ b/demonctl/tests/contracts_validate_spec.rs
@@ -139,4 +139,3 @@ fn given_no_input_specified_when_validate_then_exits_with_error() {
         .failure()
         .stderr(predicates::str::contains("Must specify"));
 }
-

--- a/demonctl/tests/contracts_validate_spec.rs
+++ b/demonctl/tests/contracts_validate_spec.rs
@@ -1,0 +1,142 @@
+use assert_cmd::Command;
+use serde_json::json;
+use std::fs;
+use tempfile::TempDir;
+
+#[test]
+fn given_valid_envelope_file_when_validate_then_exits_successfully() {
+    let temp_dir = TempDir::new().unwrap();
+    let file_path = temp_dir.path().join("valid_envelope.json");
+
+    let envelope = json!({
+        "result": {
+            "success": true,
+            "data": "test"
+        }
+    });
+
+    fs::write(&file_path, serde_json::to_string(&envelope).unwrap()).unwrap();
+
+    let mut cmd = Command::cargo_bin("demonctl").unwrap();
+    cmd.args(&[
+        "contracts",
+        "validate-envelope",
+        file_path.to_str().unwrap(),
+    ])
+    .assert()
+    .success()
+    .stdout(predicates::str::contains("✓ Valid envelope"));
+}
+
+#[test]
+fn given_invalid_envelope_file_when_validate_then_exits_with_error() {
+    let temp_dir = TempDir::new().unwrap();
+    let file_path = temp_dir.path().join("invalid_envelope.json");
+
+    let envelope = json!({
+        "invalid_field": "test"
+    });
+
+    fs::write(&file_path, serde_json::to_string(&envelope).unwrap()).unwrap();
+
+    let mut cmd = Command::cargo_bin("demonctl").unwrap();
+    cmd.args(&[
+        "contracts",
+        "validate-envelope",
+        file_path.to_str().unwrap(),
+    ])
+    .assert()
+    .failure()
+    .stderr(predicates::str::contains("✗ Invalid envelope"));
+}
+
+#[test]
+fn given_valid_envelope_on_stdin_when_validate_then_exits_successfully() {
+    let envelope = json!({
+        "result": {
+            "success": true,
+            "data": "test"
+        }
+    });
+
+    let mut cmd = Command::cargo_bin("demonctl").unwrap();
+    cmd.args(&["contracts", "validate-envelope", "--stdin"])
+        .write_stdin(serde_json::to_string(&envelope).unwrap())
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("✓ Valid envelope"));
+}
+
+#[test]
+fn given_invalid_envelope_on_stdin_when_validate_then_exits_with_error() {
+    let envelope = json!({
+        "result": {
+            "success": true,
+            "data": "test"
+        },
+        "diagnostics": [
+            {
+                "level": "invalid",
+                "message": "test"
+            }
+        ]
+    });
+
+    let mut cmd = Command::cargo_bin("demonctl").unwrap();
+    cmd.args(&["contracts", "validate-envelope", "--stdin"])
+        .write_stdin(serde_json::to_string(&envelope).unwrap())
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains("✗ Invalid envelope"));
+}
+
+#[test]
+fn given_directory_with_result_files_when_bulk_validate_then_processes_all() {
+    let temp_dir = TempDir::new().unwrap();
+
+    let valid_envelope = json!({
+        "result": {
+            "success": true,
+            "data": "valid"
+        }
+    });
+
+    let invalid_envelope = json!({
+        "missing_result": true
+    });
+
+    fs::write(
+        temp_dir.path().join("result.json"),
+        serde_json::to_string(&valid_envelope).unwrap(),
+    )
+    .unwrap();
+
+    let sub_dir = temp_dir.path().join("subdir");
+    fs::create_dir(&sub_dir).unwrap();
+    fs::write(
+        sub_dir.join("result.json"),
+        serde_json::to_string(&invalid_envelope).unwrap(),
+    )
+    .unwrap();
+
+    let mut cmd = Command::cargo_bin("demonctl").unwrap();
+    cmd.args(&[
+        "contracts",
+        "validate-envelope",
+        "--bulk",
+        temp_dir.path().to_str().unwrap(),
+    ])
+    .assert()
+    .success()
+    .stdout(predicates::str::contains("Valid: 1"));
+}
+
+#[test]
+fn given_no_input_specified_when_validate_then_exits_with_error() {
+    let mut cmd = Command::cargo_bin("demonctl").unwrap();
+    cmd.args(&["contracts", "validate-envelope"])
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains("Must specify"));
+}
+

--- a/operate-ui/Cargo.toml
+++ b/operate-ui/Cargo.toml
@@ -7,6 +7,7 @@ authors.workspace = true
 
 [dependencies]
 anyhow.workspace = true
+runtime = { path = "../runtime" }
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 tokio.workspace = true
@@ -33,3 +34,4 @@ reqwest = { version = "0.11", default-features = false, features = ["json", "rus
 [dev-dependencies]
 tempfile = "3"
 tower = "0.4"
+axum-test = "14.0"

--- a/operate-ui/src/contracts.rs
+++ b/operate-ui/src/contracts.rs
@@ -1,0 +1,26 @@
+use crate::{AppResult, AppState};
+use axum::{extract::State, response::Json};
+use runtime::contracts::{
+    validate_envelope, validate_envelope_bulk, BulkValidationResponse, ValidateEnvelopeBulkRequest,
+    ValidationResponse,
+};
+use serde_json::Value;
+use tracing::debug;
+
+pub async fn validate_envelope_endpoint(
+    State(_state): State<AppState>,
+    Json(body): Json<Value>,
+) -> AppResult<Json<ValidationResponse>> {
+    debug!("Received envelope validation request");
+    let response = validate_envelope(&body);
+    Ok(Json(response))
+}
+
+pub async fn validate_envelope_bulk_endpoint(
+    State(_state): State<AppState>,
+    Json(request): Json<ValidateEnvelopeBulkRequest>,
+) -> AppResult<Json<BulkValidationResponse>> {
+    debug!("Received bulk envelope validation request");
+    let response = validate_envelope_bulk(&request);
+    Ok(Json(response))
+}

--- a/operate-ui/src/lib.rs
+++ b/operate-ui/src/lib.rs
@@ -1,5 +1,6 @@
 // Library interface for operate-ui
 
+pub mod contracts;
 pub mod jetstream;
 pub mod routes;
 
@@ -283,6 +284,15 @@ async fn handle_static_file_error() -> impl IntoResponse {
 pub fn create_app(state: AppState) -> Router {
     Router::new()
         .route("/health", get(health))
+        // Contract validation endpoints
+        .route(
+            "/api/contracts/validate/envelope",
+            post(contracts::validate_envelope_endpoint),
+        )
+        .route(
+            "/api/contracts/validate/envelope/bulk",
+            post(contracts::validate_envelope_bulk_endpoint),
+        )
         // Legacy routes (redirect to default tenant)
         .route("/runs", get(routes::list_runs_html))
         .route("/runs/:run_id", get(routes::get_run_html))

--- a/operate-ui/tests/contracts_api_spec.rs
+++ b/operate-ui/tests/contracts_api_spec.rs
@@ -1,0 +1,159 @@
+use axum::http::StatusCode;
+use axum_test::TestServer;
+use operate_ui::{create_app, AppState};
+use serde_json::json;
+
+async fn setup_test_server() -> TestServer {
+    let state = AppState::new().await;
+    let app = create_app(state);
+    TestServer::new(app).unwrap()
+}
+
+#[tokio::test]
+async fn given_valid_envelope_when_post_validate_then_returns_valid_response() {
+    let server = setup_test_server().await;
+
+    let envelope = json!({
+        "result": {
+            "success": true,
+            "data": "test"
+        }
+    });
+
+    let response = server
+        .post("/api/contracts/validate/envelope")
+        .json(&envelope)
+        .await;
+
+    response.assert_status(StatusCode::OK);
+    let body = response.json::<serde_json::Value>();
+    assert_eq!(body["valid"], true);
+    if let Some(errors) = body["errors"].as_array() {
+        assert!(errors.is_empty());
+    }
+}
+
+#[tokio::test]
+async fn given_invalid_envelope_when_post_validate_then_returns_invalid_response() {
+    let server = setup_test_server().await;
+
+    let envelope = json!({
+        "invalid_field": "test"
+    });
+
+    let response = server
+        .post("/api/contracts/validate/envelope")
+        .json(&envelope)
+        .await;
+
+    response.assert_status(StatusCode::OK);
+    let body = response.json::<serde_json::Value>();
+    assert_eq!(body["valid"], false);
+    assert!(!body["errors"].as_array().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn given_bulk_request_when_post_validate_bulk_then_returns_results_for_each() {
+    let server = setup_test_server().await;
+
+    let request = json!({
+        "envelopes": [
+            {
+                "name": "valid",
+                "envelope": {
+                    "result": {
+                        "success": true,
+                        "data": "test"
+                    }
+                }
+            },
+            {
+                "name": "invalid",
+                "envelope": {
+                    "missing": "result"
+                }
+            }
+        ]
+    });
+
+    let response = server
+        .post("/api/contracts/validate/envelope/bulk")
+        .json(&request)
+        .await;
+
+    response.assert_status(StatusCode::OK);
+    let body = response.json::<serde_json::Value>();
+    let results = body["results"].as_array().unwrap();
+
+    assert_eq!(results.len(), 2);
+    assert_eq!(results[0]["name"], "valid");
+    assert_eq!(results[0]["valid"], true);
+    assert_eq!(results[1]["name"], "invalid");
+    assert_eq!(results[1]["valid"], false);
+}
+
+#[tokio::test]
+async fn given_malformed_json_when_post_validate_then_returns_bad_request() {
+    let server = setup_test_server().await;
+
+    let response = server
+        .post("/api/contracts/validate/envelope")
+        .content_type("application/json")
+        .text("{invalid json}")
+        .await;
+
+    assert!(response.status_code().is_client_error());
+}
+
+#[tokio::test]
+async fn given_envelope_with_all_fields_when_validate_then_returns_valid() {
+    let server = setup_test_server().await;
+
+    let envelope = json!({
+        "result": {
+            "success": true,
+            "data": {"key": "value"}
+        },
+        "diagnostics": [
+            {
+                "level": "info",
+                "message": "Processing complete"
+            }
+        ],
+        "suggestions": [
+            {
+                "type": "optimization",
+                "description": "Consider optimizing",
+                "patch": [
+                    {
+                        "op": "add",
+                        "path": "/optimization",
+                        "value": true
+                    }
+                ]
+            }
+        ],
+        "metrics": {
+            "duration": {
+                "total_ms": 100
+            },
+            "counters": {
+                "items": 42
+            }
+        },
+        "provenance": {
+            "source": {
+                "system": "test_system"
+            }
+        }
+    });
+
+    let response = server
+        .post("/api/contracts/validate/envelope")
+        .json(&envelope)
+        .await;
+
+    response.assert_status(StatusCode::OK);
+    let body = response.json::<serde_json::Value>();
+    assert_eq!(body["valid"], true);
+}

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -7,5 +7,9 @@ authors.workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
+envelope = { path = "../crates/envelope" }
+once_cell = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
+tracing = { workspace = true }
 capsules_echo = { path = "../capsules/echo" }

--- a/runtime/src/contracts.rs
+++ b/runtime/src/contracts.rs
@@ -1,0 +1,190 @@
+use anyhow::Result;
+use envelope::EnvelopeValidator;
+use once_cell::sync::Lazy;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::sync::Arc;
+use tracing::info;
+
+static ENVELOPE_VALIDATOR: Lazy<Arc<EnvelopeValidator>> = Lazy::new(|| {
+    Arc::new(
+        EnvelopeValidator::new()
+            .expect("Failed to initialize envelope validator with compiled schema"),
+    )
+});
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ValidateEnvelopeRequest {
+    #[serde(flatten)]
+    pub envelope: Value,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ValidateEnvelopeBulkRequest {
+    pub envelopes: Vec<EnvelopeBulkItem>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct EnvelopeBulkItem {
+    pub name: String,
+    pub envelope: Value,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ValidationResponse {
+    pub valid: bool,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub errors: Vec<ValidationError>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct BulkValidationResponse {
+    pub results: Vec<BulkValidationResult>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct BulkValidationResult {
+    pub name: String,
+    pub valid: bool,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub errors: Vec<ValidationError>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ValidationError {
+    pub path: String,
+    pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub schema_path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub kind: Option<String>,
+}
+
+pub fn validate_envelope(envelope: &Value) -> ValidationResponse {
+    match ENVELOPE_VALIDATOR.validate_json(envelope) {
+        Ok(_) => {
+            info!("Envelope validation successful");
+            ValidationResponse {
+                valid: true,
+                errors: vec![],
+            }
+        }
+        Err(e) => {
+            let error_msg = e.to_string();
+            info!("Envelope validation failed: {}", error_msg);
+
+            let errors = if error_msg.contains(" at ") {
+                error_msg
+                    .split(", ")
+                    .map(|part| {
+                        let parts: Vec<&str> = part.splitn(2, " at ").collect();
+                        ValidationError {
+                            message: parts.first().unwrap_or(&"Unknown error").to_string(),
+                            path: parts.get(1).unwrap_or(&"").to_string(),
+                            schema_path: None,
+                            kind: None,
+                        }
+                    })
+                    .collect()
+            } else {
+                vec![ValidationError {
+                    path: String::new(),
+                    message: error_msg,
+                    schema_path: None,
+                    kind: None,
+                }]
+            };
+
+            ValidationResponse {
+                valid: false,
+                errors,
+            }
+        }
+    }
+}
+
+pub fn validate_envelope_bulk(request: &ValidateEnvelopeBulkRequest) -> BulkValidationResponse {
+    let results = request
+        .envelopes
+        .iter()
+        .map(|item| {
+            let validation = validate_envelope(&item.envelope);
+            BulkValidationResult {
+                name: item.name.clone(),
+                valid: validation.valid,
+                errors: validation.errors,
+            }
+        })
+        .collect();
+
+    BulkValidationResponse { results }
+}
+
+pub fn get_validator() -> Arc<EnvelopeValidator> {
+    ENVELOPE_VALIDATOR.clone()
+}
+
+pub fn validate_for_publish(envelope: &Value) -> Result<()> {
+    ENVELOPE_VALIDATOR
+        .validate_json(envelope)
+        .map_err(|e| anyhow::anyhow!("Envelope failed pre-publish validation: {}", e))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn test_validate_valid_envelope() {
+        let envelope = json!({
+            "result": {
+                "success": true,
+                "data": "test"
+            }
+        });
+
+        let response = validate_envelope(&envelope);
+        assert!(response.valid);
+        assert!(response.errors.is_empty());
+    }
+
+    #[test]
+    fn test_validate_invalid_envelope() {
+        let envelope = json!({
+            "invalid_field": "test"
+        });
+
+        let response = validate_envelope(&envelope);
+        assert!(!response.valid);
+        assert!(!response.errors.is_empty());
+    }
+
+    #[test]
+    fn test_bulk_validation() {
+        let request = ValidateEnvelopeBulkRequest {
+            envelopes: vec![
+                EnvelopeBulkItem {
+                    name: "valid".to_string(),
+                    envelope: json!({
+                        "result": {
+                            "success": true,
+                            "data": "test"
+                        }
+                    }),
+                },
+                EnvelopeBulkItem {
+                    name: "invalid".to_string(),
+                    envelope: json!({
+                        "invalid_field": "test"
+                    }),
+                },
+            ],
+        };
+
+        let response = validate_envelope_bulk(&request);
+        assert_eq!(response.results.len(), 2);
+        assert!(response.results[0].valid);
+        assert!(!response.results[1].valid);
+    }
+}

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -1,2 +1,2 @@
+pub mod contracts;
 pub mod link;
-// guard: second no-op

--- a/runtime/tests/contracts_envelope_spec.rs
+++ b/runtime/tests/contracts_envelope_spec.rs
@@ -1,0 +1,232 @@
+use runtime::contracts::{
+    validate_envelope, validate_envelope_bulk, EnvelopeBulkItem, ValidateEnvelopeBulkRequest,
+};
+use serde_json::json;
+
+#[test]
+fn given_valid_minimal_envelope_when_validate_then_returns_valid() {
+    let envelope = json!({
+        "result": {
+            "success": true,
+            "data": "test"
+        }
+    });
+
+    let response = validate_envelope(&envelope);
+
+    assert!(response.valid);
+    assert!(response.errors.is_empty());
+}
+
+#[test]
+fn given_valid_envelope_with_diagnostics_when_validate_then_returns_valid() {
+    let envelope = json!({
+        "result": {
+            "success": true,
+            "data": {"key": "value"}
+        },
+        "diagnostics": [
+            {
+                "level": "info",
+                "message": "Operation completed"
+            }
+        ]
+    });
+
+    let response = validate_envelope(&envelope);
+
+    assert!(response.valid);
+    assert!(response.errors.is_empty());
+}
+
+#[test]
+fn given_envelope_with_error_result_when_validate_then_returns_valid() {
+    let envelope = json!({
+        "result": {
+            "success": false,
+            "error": {
+                "message": "Something went wrong",
+                "code": "ERR_001"
+            }
+        }
+    });
+
+    let response = validate_envelope(&envelope);
+
+    assert!(response.valid);
+    assert!(response.errors.is_empty());
+}
+
+#[test]
+fn given_envelope_missing_result_when_validate_then_returns_invalid() {
+    let envelope = json!({
+        "diagnostics": []
+    });
+
+    let response = validate_envelope(&envelope);
+
+    assert!(!response.valid);
+    assert!(!response.errors.is_empty());
+}
+
+#[test]
+fn given_envelope_with_invalid_diagnostic_level_when_validate_then_returns_invalid() {
+    let envelope = json!({
+        "result": {
+            "success": true,
+            "data": null
+        },
+        "diagnostics": [
+            {
+                "level": "invalid_level",
+                "message": "Test message"
+            }
+        ]
+    });
+
+    let response = validate_envelope(&envelope);
+
+    assert!(!response.valid);
+    assert!(!response.errors.is_empty());
+}
+
+#[test]
+fn given_bulk_request_with_mixed_envelopes_when_validate_then_returns_correct_results() {
+    let request = ValidateEnvelopeBulkRequest {
+        envelopes: vec![
+            EnvelopeBulkItem {
+                name: "valid_envelope".to_string(),
+                envelope: json!({
+                    "result": {
+                        "success": true,
+                        "data": "test"
+                    }
+                }),
+            },
+            EnvelopeBulkItem {
+                name: "invalid_envelope".to_string(),
+                envelope: json!({
+                    "invalid_field": "test"
+                }),
+            },
+            EnvelopeBulkItem {
+                name: "valid_with_error".to_string(),
+                envelope: json!({
+                    "result": {
+                        "success": false,
+                        "error": {
+                            "message": "Error occurred"
+                        }
+                    }
+                }),
+            },
+        ],
+    };
+
+    let response = validate_envelope_bulk(&request);
+
+    assert_eq!(response.results.len(), 3);
+    assert!(response.results[0].valid);
+    assert_eq!(response.results[0].name, "valid_envelope");
+    assert!(!response.results[1].valid);
+    assert_eq!(response.results[1].name, "invalid_envelope");
+    assert!(response.results[2].valid);
+    assert_eq!(response.results[2].name, "valid_with_error");
+}
+
+#[test]
+fn given_envelope_with_metrics_when_validate_then_returns_valid() {
+    let envelope = json!({
+        "result": {
+            "success": true,
+            "data": "completed"
+        },
+        "metrics": {
+            "duration": {
+                "total_ms": 150
+            },
+            "counters": {
+                "items_processed": 42
+            }
+        }
+    });
+
+    let response = validate_envelope(&envelope);
+
+    assert!(response.valid);
+    assert!(response.errors.is_empty());
+}
+
+#[test]
+fn given_envelope_with_provenance_when_validate_then_returns_valid() {
+    let envelope = json!({
+        "result": {
+            "success": true,
+            "data": "test"
+        },
+        "provenance": {
+            "source": {
+                "system": "test_system",
+                "version": "0.1.0"
+            },
+            "timestamp": "2023-01-01T00:00:00Z"
+        }
+    });
+
+    let response = validate_envelope(&envelope);
+
+    assert!(response.valid);
+    assert!(response.errors.is_empty());
+}
+
+#[test]
+fn given_envelope_with_all_optional_fields_when_validate_then_returns_valid() {
+    let envelope = json!({
+        "result": {
+            "success": true,
+            "data": {"complex": "data"}
+        },
+        "diagnostics": [
+            {
+                "level": "warning",
+                "message": "Warning message",
+                "timestamp": "2023-01-01T00:00:00Z",
+                "source": "test_module"
+            }
+        ],
+        "suggestions": [
+            {
+                "type": "modification",
+                "description": "Try this instead",
+                "patch": [
+                    {
+                        "op": "replace",
+                        "path": "/field",
+                        "value": "new_value"
+                    }
+                ]
+            }
+        ],
+        "metrics": {
+            "duration": {
+                "total_ms": 123
+            },
+            "resources": {
+                "memory_bytes": 4096
+            }
+        },
+        "provenance": {
+            "source": {
+                "system": "test_system",
+                "version": "1.0.0"
+            },
+            "timestamp": "2023-01-01T00:00:00Z",
+            "trace_id": "abc123"
+        }
+    });
+
+    let response = validate_envelope(&envelope);
+
+    assert!(response.valid);
+    assert!(response.errors.is_empty());
+}


### PR DESCRIPTION
## Summary
- Add /api/contracts/validate/envelope (and bulk) endpoints
- Cache compiled envelope schema; return JSON Pointer errors
- Add demonctl contracts validate-envelope command (local validation)
- Integrate runtime pre-emit validation hooks

## Testing
- cargo fmt
- cargo clippy --workspace --all-features -- -D warnings
- cargo test --workspace --all-features -- --nocapture
- demonctl contracts validate-envelope fixtures/...
- curl POST /api/contracts/validate/envelope < valid/invalid payloads

Fixes #128

Review-lock: 49f2f76a8378d5d83892f0523e1f95faf85feaa9