### PR TITLE
feat(secrets): add vault stub provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -598,6 +598,7 @@ name = "config-loader"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "dirs",
  "jsonschema 0.18.3",
  "once_cell",
  "regex",
@@ -808,6 +809,27 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+]
+
+[[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1742,6 +1764,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
+name = "libredox"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "416f7e718bdb06000964960ffa43b4335ad4012ae8b99060261aa4a8088d5ccb"
+dependencies = [
+ "bitflags 2.9.4",
+ "libc",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2019,6 +2051,12 @@ dependencies = [
  "tracing-subscriber",
  "uuid",
 ]
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "outref"
@@ -2406,6 +2444,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
 dependencies = [
  "bitflags 2.9.4",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.16",
+ "libredox",
+ "thiserror 1.0.69",
 ]
 
 [[package]]

--- a/crates/config-loader/Cargo.toml
+++ b/crates/config-loader/Cargo.toml
@@ -15,6 +15,7 @@ jsonschema.workspace = true
 once_cell.workspace = true
 regex.workspace = true
 tempfile = "3.8"
+dirs = "5.0"
 
 [dev-dependencies]
 tempfile = "3.8"

--- a/crates/config-loader/src/lib.rs
+++ b/crates/config-loader/src/lib.rs
@@ -7,8 +7,10 @@ use std::path::{Path, PathBuf};
 use thiserror::Error;
 use tracing::{debug, instrument};
 
+pub mod provider_factory;
 pub mod secrets;
 pub mod secrets_store;
+pub use provider_factory::{ProviderFactoryError, SecretProviderFactory, VaultStubProvider};
 pub use secrets::{EnvFileSecretProvider, SecretError, SecretProvider};
 pub use secrets_store::{SecretsStore, StoreError};
 

--- a/crates/config-loader/src/provider_factory.rs
+++ b/crates/config-loader/src/provider_factory.rs
@@ -1,0 +1,491 @@
+use crate::secrets::{EnvFileSecretProvider, SecretProvider};
+use std::env;
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum ProviderFactoryError {
+    #[error("Unknown provider type: {provider_type}")]
+    UnknownProviderType { provider_type: String },
+
+    #[error("Vault configuration error: {message}")]
+    VaultConfigError { message: String },
+
+    #[error("Provider initialization failed: {message}")]
+    InitializationFailed { message: String },
+}
+
+pub struct SecretProviderFactory;
+
+impl SecretProviderFactory {
+    /// Create a secret provider based on environment configuration
+    ///
+    /// Uses CONFIG_SECRETS_PROVIDER environment variable:
+    /// - "envfile" (default): EnvFileSecretProvider
+    /// - "vault": VaultStubProvider
+    pub fn create() -> Result<Box<dyn SecretProvider>, ProviderFactoryError> {
+        let provider_type =
+            env::var("CONFIG_SECRETS_PROVIDER").unwrap_or_else(|_| "envfile".to_string());
+
+        match provider_type.as_str() {
+            "envfile" => Ok(Box::new(EnvFileSecretProvider::new())),
+            "vault" => {
+                let vault_provider = VaultStubProvider::from_env()
+                    .map_err(|e| ProviderFactoryError::VaultConfigError { message: e })?;
+                Ok(Box::new(vault_provider))
+            }
+            other => Err(ProviderFactoryError::UnknownProviderType {
+                provider_type: other.to_string(),
+            }),
+        }
+    }
+
+    /// Create a specific provider type for testing or explicit usage
+    pub fn create_envfile() -> Box<dyn SecretProvider> {
+        Box::new(EnvFileSecretProvider::new())
+    }
+
+    pub fn create_vault(
+        vault_addr: Option<String>,
+        vault_token: Option<String>,
+    ) -> Result<Box<dyn SecretProvider>, ProviderFactoryError> {
+        let vault_provider = VaultStubProvider::new(vault_addr, vault_token)
+            .map_err(|e| ProviderFactoryError::VaultConfigError { message: e })?;
+        Ok(Box::new(vault_provider))
+    }
+}
+
+/// Vault stub provider for testing and development
+///
+/// This provider simulates a Vault-like interface for secret storage.
+/// It can operate in two modes:
+/// - File mode: Stores secrets in JSON files under ~/.demon/vault_stub/
+/// - HTTP mode: Makes HTTP requests to VAULT_ADDR (minimal implementation)
+pub struct VaultStubProvider {
+    #[allow(dead_code)] // Stored for future HTTP implementation
+    vault_addr: String,
+    #[allow(dead_code)] // Stored for future HTTP implementation
+    vault_token: Option<String>,
+    mode: VaultMode,
+}
+
+#[derive(Debug, Clone)]
+enum VaultMode {
+    File { base_path: std::path::PathBuf },
+    Http,
+}
+
+impl VaultStubProvider {
+    /// Create a new VaultStubProvider with explicit configuration
+    pub fn new(vault_addr: Option<String>, vault_token: Option<String>) -> Result<Self, String> {
+        let addr = vault_addr.unwrap_or_else(|| "file://vault_stub".to_string());
+
+        let mode = if addr.starts_with("file://") {
+            let path = addr.strip_prefix("file://").unwrap();
+            let base_path = if path.starts_with('/') {
+                std::path::PathBuf::from(path)
+            } else {
+                dirs::home_dir()
+                    .unwrap_or_else(|| std::path::PathBuf::from("."))
+                    .join(".demon")
+                    .join(path)
+            };
+            VaultMode::File { base_path }
+        } else if addr.starts_with("http://") || addr.starts_with("https://") {
+            VaultMode::Http
+        } else {
+            return Err(format!(
+                "Invalid VAULT_ADDR format: {}. Must start with file://, http://, or https://",
+                addr
+            ));
+        };
+
+        Ok(Self {
+            vault_addr: addr,
+            vault_token,
+            mode,
+        })
+    }
+
+    /// Create a VaultStubProvider from environment variables
+    pub fn from_env() -> Result<Self, String> {
+        let vault_addr = env::var("VAULT_ADDR").ok();
+        let vault_token = env::var("VAULT_TOKEN").ok();
+        Self::new(vault_addr, vault_token)
+    }
+
+    /// Resolve a secret using the vault stub
+    fn resolve_secret(
+        &self,
+        scope: &str,
+        key: &str,
+    ) -> Result<String, crate::secrets::SecretError> {
+        match &self.mode {
+            VaultMode::File { base_path } => self.resolve_from_file(base_path, scope, key),
+            VaultMode::Http => self.resolve_from_http(scope, key),
+        }
+    }
+
+    /// Store a secret using the vault stub
+    fn store_secret(&self, scope: &str, key: &str, value: &str) -> Result<(), String> {
+        match &self.mode {
+            VaultMode::File { base_path } => self.store_to_file(base_path, scope, key, value),
+            VaultMode::Http => self.store_to_http(scope, key, value),
+        }
+    }
+
+    /// Delete a secret using the vault stub
+    fn delete_secret(&self, scope: &str, key: &str) -> Result<(), String> {
+        match &self.mode {
+            VaultMode::File { base_path } => self.delete_from_file(base_path, scope, key),
+            VaultMode::Http => self.delete_from_http(scope, key),
+        }
+    }
+
+    // File-based operations
+    fn resolve_from_file(
+        &self,
+        base_path: &std::path::Path,
+        scope: &str,
+        key: &str,
+    ) -> Result<String, crate::secrets::SecretError> {
+        use crate::secrets::SecretError;
+
+        let scope_file = base_path.join(format!("{}.json", scope));
+
+        if !scope_file.exists() {
+            return Err(SecretError::SecretNotFound {
+                scope: scope.to_string(),
+                key: key.to_string(),
+            });
+        }
+
+        let content =
+            std::fs::read_to_string(&scope_file).map_err(|e| SecretError::SecretsFileError {
+                path: scope_file.to_string_lossy().to_string(),
+                message: e.to_string(),
+            })?;
+
+        let secrets: serde_json::Value =
+            serde_json::from_str(&content).map_err(|e| SecretError::SecretsParseError {
+                message: e.to_string(),
+            })?;
+
+        if let Some(value) = secrets.get(key).and_then(|v| v.as_str()) {
+            Ok(value.to_string())
+        } else {
+            Err(SecretError::SecretNotFound {
+                scope: scope.to_string(),
+                key: key.to_string(),
+            })
+        }
+    }
+
+    fn store_to_file(
+        &self,
+        base_path: &std::path::Path,
+        scope: &str,
+        key: &str,
+        value: &str,
+    ) -> Result<(), String> {
+        // Create directory if it doesn't exist
+        std::fs::create_dir_all(base_path)
+            .map_err(|e| format!("Failed to create vault stub directory: {}", e))?;
+
+        let scope_file = base_path.join(format!("{}.json", scope));
+
+        // Load existing secrets or create new
+        let mut secrets = if scope_file.exists() {
+            let content = std::fs::read_to_string(&scope_file)
+                .map_err(|e| format!("Failed to read scope file: {}", e))?;
+
+            serde_json::from_str(&content)
+                .map_err(|e| format!("Failed to parse scope file: {}", e))?
+        } else {
+            serde_json::json!({})
+        };
+
+        // Update the secret
+        if let Some(obj) = secrets.as_object_mut() {
+            obj.insert(
+                key.to_string(),
+                serde_json::Value::String(value.to_string()),
+            );
+        }
+
+        // Write back atomically
+        let temp_file = scope_file.with_extension("tmp");
+        std::fs::write(&temp_file, serde_json::to_string_pretty(&secrets).unwrap())
+            .map_err(|e| format!("Failed to write temp file: {}", e))?;
+
+        std::fs::rename(&temp_file, &scope_file)
+            .map_err(|e| format!("Failed to rename temp file: {}", e))?;
+
+        // Set appropriate permissions on Unix systems
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let permissions = std::fs::Permissions::from_mode(0o600);
+            std::fs::set_permissions(&scope_file, permissions)
+                .map_err(|e| format!("Failed to set file permissions: {}", e))?;
+        }
+
+        Ok(())
+    }
+
+    fn delete_from_file(
+        &self,
+        base_path: &std::path::Path,
+        scope: &str,
+        key: &str,
+    ) -> Result<(), String> {
+        let scope_file = base_path.join(format!("{}.json", scope));
+
+        if !scope_file.exists() {
+            return Err(format!("Secret {}/{} not found", scope, key));
+        }
+
+        let content = std::fs::read_to_string(&scope_file)
+            .map_err(|e| format!("Failed to read scope file: {}", e))?;
+
+        let mut secrets: serde_json::Value = serde_json::from_str(&content)
+            .map_err(|e| format!("Failed to parse scope file: {}", e))?;
+
+        if let Some(obj) = secrets.as_object_mut() {
+            if obj.remove(key).is_none() {
+                return Err(format!("Secret {}/{} not found", scope, key));
+            }
+
+            // If scope is now empty, remove the file
+            if obj.is_empty() {
+                std::fs::remove_file(&scope_file)
+                    .map_err(|e| format!("Failed to remove empty scope file: {}", e))?;
+            } else {
+                // Write back the updated secrets
+                let temp_file = scope_file.with_extension("tmp");
+                std::fs::write(&temp_file, serde_json::to_string_pretty(&secrets).unwrap())
+                    .map_err(|e| format!("Failed to write temp file: {}", e))?;
+
+                std::fs::rename(&temp_file, &scope_file)
+                    .map_err(|e| format!("Failed to rename temp file: {}", e))?;
+            }
+        }
+
+        Ok(())
+    }
+
+    // HTTP-based operations (minimal implementation)
+    fn resolve_from_http(
+        &self,
+        scope: &str,
+        key: &str,
+    ) -> Result<String, crate::secrets::SecretError> {
+        // This is a minimal stub - in a real implementation you'd use an HTTP client
+        // For now, just return an error indicating HTTP mode is not fully implemented
+        tracing::warn!(
+            "HTTP mode vault stub accessed for {}/{} - not fully implemented",
+            scope,
+            key
+        );
+        Err(crate::secrets::SecretError::SecretNotFound {
+            scope: scope.to_string(),
+            key: key.to_string(),
+        })
+    }
+
+    fn store_to_http(&self, scope: &str, key: &str, _value: &str) -> Result<(), String> {
+        tracing::warn!(
+            "HTTP mode vault stub store operation for {}/{} - not fully implemented",
+            scope,
+            key
+        );
+        Err("HTTP mode not fully implemented".to_string())
+    }
+
+    fn delete_from_http(&self, scope: &str, key: &str) -> Result<(), String> {
+        tracing::warn!(
+            "HTTP mode vault stub delete operation for {}/{} - not fully implemented",
+            scope,
+            key
+        );
+        Err("HTTP mode not fully implemented".to_string())
+    }
+}
+
+impl SecretProvider for VaultStubProvider {
+    fn resolve(&self, scope: &str, key: &str) -> Result<String, crate::secrets::SecretError> {
+        tracing::debug!("VaultStubProvider resolving secret {}/{}", scope, key);
+        self.resolve_secret(scope, key)
+    }
+}
+
+// Public interface for CLI operations
+impl VaultStubProvider {
+    pub fn put(&self, scope: &str, key: &str, value: &str) -> Result<(), String> {
+        tracing::debug!("VaultStubProvider storing secret {}/{}", scope, key);
+        self.store_secret(scope, key, value)
+    }
+
+    pub fn delete(&self, scope: &str, key: &str) -> Result<(), String> {
+        tracing::debug!("VaultStubProvider deleting secret {}/{}", scope, key);
+        self.delete_secret(scope, key)
+    }
+
+    pub fn list(
+        &self,
+        scope: Option<&str>,
+    ) -> Result<std::collections::HashMap<String, std::collections::HashMap<String, String>>, String>
+    {
+        match &self.mode {
+            VaultMode::File { base_path } => self.list_from_file(base_path, scope),
+            VaultMode::Http => {
+                tracing::warn!("HTTP mode vault stub list operation - not fully implemented");
+                Err("HTTP mode not fully implemented".to_string())
+            }
+        }
+    }
+
+    fn list_from_file(
+        &self,
+        base_path: &std::path::Path,
+        scope_filter: Option<&str>,
+    ) -> Result<std::collections::HashMap<String, std::collections::HashMap<String, String>>, String>
+    {
+        use std::collections::HashMap;
+
+        let mut result = HashMap::new();
+
+        if !base_path.exists() {
+            return Ok(result);
+        }
+
+        let entries = std::fs::read_dir(base_path)
+            .map_err(|e| format!("Failed to read vault stub directory: {}", e))?;
+
+        for entry in entries {
+            let entry = entry.map_err(|e| format!("Failed to read directory entry: {}", e))?;
+            let path = entry.path();
+
+            if path.extension().and_then(|s| s.to_str()) == Some("json") {
+                if let Some(file_stem) = path.file_stem().and_then(|s| s.to_str()) {
+                    let scope_name = file_stem.to_string();
+
+                    // Apply scope filter if provided
+                    if let Some(filter) = scope_filter {
+                        if scope_name != filter {
+                            continue;
+                        }
+                    }
+
+                    let content = std::fs::read_to_string(&path).map_err(|e| {
+                        format!("Failed to read scope file {}: {}", path.display(), e)
+                    })?;
+
+                    let secrets: serde_json::Value =
+                        serde_json::from_str(&content).map_err(|e| {
+                            format!("Failed to parse scope file {}: {}", path.display(), e)
+                        })?;
+
+                    if let Some(obj) = secrets.as_object() {
+                        let mut scope_secrets = HashMap::new();
+                        for (key, value) in obj {
+                            if let Some(str_value) = value.as_str() {
+                                // Redact the value for listing
+                                scope_secrets.insert(
+                                    key.clone(),
+                                    crate::secrets_store::redact_value(str_value),
+                                );
+                            }
+                        }
+                        if !scope_secrets.is_empty() {
+                            result.insert(scope_name, scope_secrets);
+                        }
+                    }
+                }
+            }
+        }
+
+        Ok(result)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_factory_default_envfile() {
+        // Default should be envfile when no env var is set
+        std::env::remove_var("CONFIG_SECRETS_PROVIDER");
+        let provider = SecretProviderFactory::create().unwrap();
+        // We can't easily test the concrete type, but we can test behavior
+        // This just ensures it doesn't panic
+        drop(provider);
+    }
+
+    #[test]
+    fn test_factory_vault_creation() {
+        std::env::set_var("CONFIG_SECRETS_PROVIDER", "vault");
+        std::env::set_var("VAULT_ADDR", "file://test_vault");
+
+        let provider = SecretProviderFactory::create().unwrap();
+        drop(provider);
+
+        std::env::remove_var("CONFIG_SECRETS_PROVIDER");
+        std::env::remove_var("VAULT_ADDR");
+    }
+
+    #[test]
+    fn test_vault_stub_file_operations() {
+        let temp_dir = TempDir::new().unwrap();
+        let vault_addr = format!("file://{}", temp_dir.path().display());
+
+        let provider = VaultStubProvider::new(Some(vault_addr), None).unwrap();
+
+        // Test store and resolve
+        provider.put("test", "key1", "value1").unwrap();
+        let result = provider.resolve("test", "key1").unwrap();
+        assert_eq!(result, "value1");
+
+        // Test delete
+        provider.delete("test", "key1").unwrap();
+        assert!(provider.resolve("test", "key1").is_err());
+    }
+
+    #[test]
+    fn test_vault_stub_list() {
+        let temp_dir = TempDir::new().unwrap();
+        let vault_addr = format!("file://{}", temp_dir.path().display());
+
+        let provider = VaultStubProvider::new(Some(vault_addr), None).unwrap();
+
+        // Store some test secrets
+        provider
+            .put("scope1", "key1", "verylongsecretvalue")
+            .unwrap();
+        provider.put("scope1", "key2", "short").unwrap();
+        provider.put("scope2", "key1", "anothersecret").unwrap();
+
+        // Test list all
+        let all_secrets = provider.list(None).unwrap();
+        assert_eq!(all_secrets.len(), 2);
+        assert!(all_secrets.contains_key("scope1"));
+        assert!(all_secrets.contains_key("scope2"));
+
+        // Values should be redacted
+        assert_eq!(all_secrets["scope1"]["key1"], "ver***");
+        assert_eq!(all_secrets["scope1"]["key2"], "***");
+
+        // Test list specific scope
+        let scope1_secrets = provider.list(Some("scope1")).unwrap();
+        assert_eq!(scope1_secrets.len(), 1);
+        assert!(scope1_secrets.contains_key("scope1"));
+        assert_eq!(scope1_secrets["scope1"].len(), 2);
+    }
+
+    #[test]
+    fn test_vault_stub_invalid_addr() {
+        let result = VaultStubProvider::new(Some("invalid://addr".to_string()), None);
+        assert!(result.is_err());
+    }
+}

--- a/crates/config-loader/src/provider_factory.rs
+++ b/crates/config-loader/src/provider_factory.rs
@@ -120,7 +120,10 @@ impl VaultStubProvider {
         }
 
         // Only allow alphanumeric characters, hyphens, and underscores
-        if !scope.chars().all(|c| c.is_alphanumeric() || c == '-' || c == '_') {
+        if !scope
+            .chars()
+            .all(|c| c.is_alphanumeric() || c == '-' || c == '_')
+        {
             return Err(format!(
                 "Invalid scope name '{}': only alphanumeric characters, hyphens, and underscores are allowed",
                 scope
@@ -128,7 +131,11 @@ impl VaultStubProvider {
         }
 
         // Additional safety check for specific dangerous patterns
-        if scope.contains("..") || scope.starts_with('.') || scope.starts_with('/') || scope.starts_with('\\') {
+        if scope.contains("..")
+            || scope.starts_with('.')
+            || scope.starts_with('/')
+            || scope.starts_with('\\')
+        {
             return Err(format!(
                 "Invalid scope name '{}': path traversal patterns are not allowed",
                 scope
@@ -144,11 +151,12 @@ impl VaultStubProvider {
         scope: &str,
         key: &str,
     ) -> Result<String, crate::secrets::SecretError> {
-        Self::validate_scope_name(scope)
-            .map_err(|e| crate::secrets::SecretError::SecretsFileError {
+        Self::validate_scope_name(scope).map_err(|e| {
+            crate::secrets::SecretError::SecretsFileError {
                 path: scope.to_string(),
                 message: e,
-            })?;
+            }
+        })?;
 
         match &self.mode {
             VaultMode::File { base_path } => self.resolve_from_file(base_path, scope, key),
@@ -545,19 +553,31 @@ mod tests {
             "scope..parent",
             "scope with spaces",
             "scope!@#$",
-            "",  // empty scope
+            "", // empty scope
         ];
 
         for dangerous_scope in dangerous_scopes {
             // All these operations should fail with scope validation errors
-            assert!(provider.put(dangerous_scope, "key", "value").is_err(),
-                    "put should fail for dangerous scope: {}", dangerous_scope);
-            assert!(provider.resolve(dangerous_scope, "key").is_err(),
-                    "resolve should fail for dangerous scope: {}", dangerous_scope);
-            assert!(provider.delete(dangerous_scope, "key").is_err(),
-                    "delete should fail for dangerous scope: {}", dangerous_scope);
-            assert!(provider.list(Some(dangerous_scope)).is_err(),
-                    "list should fail for dangerous scope: {}", dangerous_scope);
+            assert!(
+                provider.put(dangerous_scope, "key", "value").is_err(),
+                "put should fail for dangerous scope: {}",
+                dangerous_scope
+            );
+            assert!(
+                provider.resolve(dangerous_scope, "key").is_err(),
+                "resolve should fail for dangerous scope: {}",
+                dangerous_scope
+            );
+            assert!(
+                provider.delete(dangerous_scope, "key").is_err(),
+                "delete should fail for dangerous scope: {}",
+                dangerous_scope
+            );
+            assert!(
+                provider.list(Some(dangerous_scope)).is_err(),
+                "list should fail for dangerous scope: {}",
+                dangerous_scope
+            );
         }
 
         // Test valid scope names should work
@@ -565,12 +585,21 @@ mod tests {
 
         for valid_scope in valid_scopes {
             // These should all succeed
-            assert!(provider.put(valid_scope, "key", "value").is_ok(),
-                    "put should succeed for valid scope: {}", valid_scope);
-            assert!(provider.resolve(valid_scope, "key").is_ok(),
-                    "resolve should succeed for valid scope: {}", valid_scope);
-            assert!(provider.delete(valid_scope, "key").is_ok(),
-                    "delete should succeed for valid scope: {}", valid_scope);
+            assert!(
+                provider.put(valid_scope, "key", "value").is_ok(),
+                "put should succeed for valid scope: {}",
+                valid_scope
+            );
+            assert!(
+                provider.resolve(valid_scope, "key").is_ok(),
+                "resolve should succeed for valid scope: {}",
+                valid_scope
+            );
+            assert!(
+                provider.delete(valid_scope, "key").is_ok(),
+                "delete should succeed for valid scope: {}",
+                valid_scope
+            );
         }
     }
 }

--- a/demonctl/tests/secrets_provider_cli_spec.rs
+++ b/demonctl/tests/secrets_provider_cli_spec.rs
@@ -1,0 +1,363 @@
+use std::env;
+use std::process::Command;
+use tempfile::TempDir;
+
+fn demonctl_binary() -> Command {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_demonctl"));
+    cmd.env_clear(); // Start with clean environment
+    cmd
+}
+
+#[test]
+fn test_secrets_set_get_with_envfile_provider() {
+    let temp_dir = TempDir::new().unwrap();
+    let secrets_file = temp_dir.path().join("test_secrets.json");
+
+    // Set a secret using envfile provider
+    let output = demonctl_binary()
+        .args([
+            "secrets",
+            "set",
+            "test/key",
+            "--secrets-file",
+            secrets_file.to_str().unwrap(),
+            "--provider",
+            "envfile",
+            "test-value",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "Set command failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(String::from_utf8_lossy(&output.stdout).contains("✓ Secret test/key set successfully"));
+
+    // Get the secret back
+    let output = demonctl_binary()
+        .args([
+            "secrets",
+            "get",
+            "test/key",
+            "--secrets-file",
+            secrets_file.to_str().unwrap(),
+            "--provider",
+            "envfile",
+            "--raw",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "Get command failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), "test-value");
+}
+
+#[test]
+fn test_secrets_set_get_with_vault_provider() {
+    let temp_dir = TempDir::new().unwrap();
+    let vault_dir = temp_dir.path().join("vault");
+
+    // Set a secret using vault provider
+    let output = demonctl_binary()
+        .env("VAULT_ADDR", format!("file://{}", vault_dir.display()))
+        .args([
+            "secrets",
+            "set",
+            "api/token",
+            "--provider",
+            "vault",
+            "vault-test-token",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "Set command failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(String::from_utf8_lossy(&output.stdout)
+        .contains("✓ Secret api/token set successfully in vault"));
+
+    // Get the secret back
+    let output = demonctl_binary()
+        .env("VAULT_ADDR", format!("file://{}", vault_dir.display()))
+        .args([
+            "secrets",
+            "get",
+            "api/token",
+            "--provider",
+            "vault",
+            "--raw",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "Get command failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout).trim(),
+        "vault-test-token"
+    );
+}
+
+#[test]
+fn test_secrets_list_with_vault_provider() {
+    let temp_dir = TempDir::new().unwrap();
+    let vault_dir = temp_dir.path().join("vault");
+
+    // Set multiple secrets
+    for (scope, key, value) in [
+        ("db", "password", "db-secret"),
+        ("db", "username", "admin"),
+        ("api", "key", "api-secret"),
+    ] {
+        let output = demonctl_binary()
+            .env("VAULT_ADDR", format!("file://{}", vault_dir.display()))
+            .args([
+                "secrets",
+                "set",
+                &format!("{}/{}", scope, key),
+                "--provider",
+                "vault",
+                value,
+            ])
+            .output()
+            .unwrap();
+
+        assert!(
+            output.status.success(),
+            "Set command failed for {}/{}: {}",
+            scope,
+            key,
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    // List all secrets
+    let output = demonctl_binary()
+        .env("VAULT_ADDR", format!("file://{}", vault_dir.display()))
+        .args(["secrets", "list", "--provider", "vault"])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "List command failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Secrets (vault):"));
+    assert!(stdout.contains("db:"));
+    assert!(stdout.contains("api:"));
+    assert!(stdout.contains("password: db-***")); // Should be redacted
+    assert!(stdout.contains("key: api***")); // Should be redacted
+
+    // List specific scope
+    let output = demonctl_binary()
+        .env("VAULT_ADDR", format!("file://{}", vault_dir.display()))
+        .args(["secrets", "list", "--scope", "db", "--provider", "vault"])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "List scope command failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Secrets in scope 'db' (vault):"));
+    assert!(stdout.contains("password: db-***"));
+    assert!(stdout.contains("username: ***"));
+    assert!(!stdout.contains("api:"));
+}
+
+#[test]
+fn test_secrets_delete_with_vault_provider() {
+    let temp_dir = TempDir::new().unwrap();
+    let vault_dir = temp_dir.path().join("vault");
+
+    // Set a secret
+    let output = demonctl_binary()
+        .env("VAULT_ADDR", format!("file://{}", vault_dir.display()))
+        .args([
+            "secrets",
+            "set",
+            "temp/data",
+            "--provider",
+            "vault",
+            "temporary-value",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+
+    // Verify it exists
+    let output = demonctl_binary()
+        .env("VAULT_ADDR", format!("file://{}", vault_dir.display()))
+        .args([
+            "secrets",
+            "get",
+            "temp/data",
+            "--provider",
+            "vault",
+            "--raw",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout).trim(),
+        "temporary-value"
+    );
+
+    // Delete the secret
+    let output = demonctl_binary()
+        .env("VAULT_ADDR", format!("file://{}", vault_dir.display()))
+        .args(["secrets", "delete", "temp/data", "--provider", "vault"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    assert!(
+        String::from_utf8_lossy(&output.stdout).contains("✓ Secret temp/data deleted from vault")
+    );
+
+    // Verify it's gone
+    let output = demonctl_binary()
+        .env("VAULT_ADDR", format!("file://{}", vault_dir.display()))
+        .args(["secrets", "get", "temp/data", "--provider", "vault"])
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("Failed to get secret from vault"));
+}
+
+#[test]
+fn test_secrets_file_warning_with_vault_provider() {
+    let temp_dir = TempDir::new().unwrap();
+    let vault_dir = temp_dir.path().join("vault");
+    let dummy_secrets_file = temp_dir.path().join("dummy.json");
+
+    // Try to use --secrets-file with vault provider (should warn)
+    let output = demonctl_binary()
+        .env("VAULT_ADDR", format!("file://{}", vault_dir.display()))
+        .args([
+            "secrets",
+            "set",
+            "test/key",
+            "--secrets-file",
+            dummy_secrets_file.to_str().unwrap(),
+            "--provider",
+            "vault",
+            "test-value",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("⚠ Warning: --secrets-file is ignored when using vault provider"));
+}
+
+#[test]
+fn test_vault_provider_initialization_failure() {
+    // Try to use vault provider without proper configuration
+    let output = demonctl_binary()
+        .env("VAULT_ADDR", "invalid://protocol")
+        .args(["secrets", "get", "test/key", "--provider", "vault"])
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("Failed to initialize vault provider"));
+}
+
+#[test]
+fn test_provider_help_text() {
+    let output = demonctl_binary()
+        .args(["secrets", "set", "--help"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("--provider"));
+    assert!(stdout.contains("Secret provider to use"));
+    assert!(stdout.contains("envfile"));
+    assert!(stdout.contains("vault"));
+}
+
+#[test]
+fn test_envfile_provider_backwards_compatibility() {
+    let temp_dir = TempDir::new().unwrap();
+    let secrets_file = temp_dir.path().join("compat_test.json");
+
+    // Set secret without specifying provider (should default to envfile)
+    let output = demonctl_binary()
+        .args([
+            "secrets",
+            "set",
+            "compat/test",
+            "--secrets-file",
+            secrets_file.to_str().unwrap(),
+            "compat-value",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+
+    // Get secret with explicit envfile provider
+    let output = demonctl_binary()
+        .args([
+            "secrets",
+            "get",
+            "compat/test",
+            "--secrets-file",
+            secrets_file.to_str().unwrap(),
+            "--provider",
+            "envfile",
+            "--raw",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout).trim(),
+        "compat-value"
+    );
+
+    // Get secret without specifying provider (should still work)
+    let output = demonctl_binary()
+        .args([
+            "secrets",
+            "get",
+            "compat/test",
+            "--secrets-file",
+            secrets_file.to_str().unwrap(),
+            "--raw",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout).trim(),
+        "compat-value"
+    );
+}

--- a/runtime/src/link/router.rs
+++ b/runtime/src/link/router.rs
@@ -1,6 +1,7 @@
 use anyhow::{Context, Result};
 use config_loader::{
-    ConfigError, ConfigManager, EnvFileSecretProvider, SecretProvider, ValidationError,
+    ConfigError, ConfigManager, EnvFileSecretProvider, SecretProvider, SecretProviderFactory,
+    ValidationError,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
@@ -37,16 +38,30 @@ pub struct Router {
 
 impl Router {
     pub fn new() -> Self {
+        // Use factory to create provider based on environment configuration
+        let secret_provider = SecretProviderFactory::create()
+            .unwrap_or_else(|e| {
+                tracing::warn!("Failed to create secret provider from factory: {}. Falling back to EnvFileSecretProvider", e);
+                Box::new(EnvFileSecretProvider::new())
+            });
+
         Self {
             config_manager: ConfigManager::new(),
-            secret_provider: Box::new(EnvFileSecretProvider::new()),
+            secret_provider,
         }
     }
 
     pub fn with_config_manager(config_manager: ConfigManager) -> Self {
+        // Use factory to create provider based on environment configuration
+        let secret_provider = SecretProviderFactory::create()
+            .unwrap_or_else(|e| {
+                tracing::warn!("Failed to create secret provider from factory: {}. Falling back to EnvFileSecretProvider", e);
+                Box::new(EnvFileSecretProvider::new())
+            });
+
         Self {
             config_manager,
-            secret_provider: Box::new(EnvFileSecretProvider::new()),
+            secret_provider,
         }
     }
 

--- a/runtime/tests/provider_integration_spec.rs
+++ b/runtime/tests/provider_integration_spec.rs
@@ -1,0 +1,272 @@
+use config_loader::{SecretProvider, SecretProviderFactory, VaultStubProvider};
+use runtime::link::router::Router;
+use std::env;
+use std::fs;
+use tempfile::TempDir;
+
+#[test]
+fn test_factory_creates_envfile_provider_by_default() {
+    // Ensure no CONFIG_SECRETS_PROVIDER env var is set
+    env::remove_var("CONFIG_SECRETS_PROVIDER");
+
+    let provider = SecretProviderFactory::create().unwrap();
+    // Can't easily test the concrete type, but we can test that it doesn't panic
+    drop(provider);
+}
+
+#[test]
+fn test_factory_creates_vault_provider_when_configured() {
+    let temp_dir = TempDir::new().unwrap();
+    let vault_path = temp_dir.path().join("vault_test");
+
+    env::set_var("CONFIG_SECRETS_PROVIDER", "vault");
+    env::set_var("VAULT_ADDR", format!("file://{}", vault_path.display()));
+
+    let provider = SecretProviderFactory::create().unwrap();
+    drop(provider);
+
+    // Clean up
+    env::remove_var("CONFIG_SECRETS_PROVIDER");
+    env::remove_var("VAULT_ADDR");
+}
+
+#[test]
+fn test_router_uses_factory_for_provider_selection() {
+    let temp_dir = TempDir::new().unwrap();
+    let vault_path = temp_dir.path().join("vault_test");
+
+    // Test with vault provider
+    env::set_var("CONFIG_SECRETS_PROVIDER", "vault");
+    env::set_var("VAULT_ADDR", format!("file://{}", vault_path.display()));
+
+    let router = Router::new();
+    // This should not panic and should successfully create router with vault provider
+    drop(router);
+
+    // Test with envfile provider
+    env::set_var("CONFIG_SECRETS_PROVIDER", "envfile");
+    env::remove_var("VAULT_ADDR");
+
+    let router = Router::new();
+    drop(router);
+
+    // Clean up
+    env::remove_var("CONFIG_SECRETS_PROVIDER");
+}
+
+#[tokio::test]
+async fn test_router_handles_vault_secret_resolution_failure() {
+    let temp_dir = TempDir::new().unwrap();
+    let contracts_dir = temp_dir.path().join("contracts");
+    let config_dir = temp_dir.path().join("config");
+    let vault_dir = temp_dir.path().join("vault");
+
+    // Create test directories
+    fs::create_dir_all(contracts_dir.join("config")).unwrap();
+    fs::create_dir_all(&config_dir).unwrap();
+    fs::create_dir_all(&vault_dir).unwrap();
+
+    // Create echo schema
+    let schema_content = r#"{
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+            "messagePrefix": { "type": "string", "default": "" },
+            "enableTrim": { "type": "boolean", "default": true },
+            "apiKey": { "type": "string" }
+        },
+        "required": ["messagePrefix", "enableTrim", "apiKey"],
+        "additionalProperties": false
+    }"#;
+
+    fs::write(
+        contracts_dir.join("config/echo-config.v1.json"),
+        schema_content,
+    )
+    .unwrap();
+
+    // Create config with secret reference
+    let config_content = r#"{
+        "messagePrefix": "Test: ",
+        "enableTrim": true,
+        "apiKey": "secret://api/key"
+    }"#;
+
+    fs::write(config_dir.join("echo.json"), config_content).unwrap();
+
+    // Set up vault provider without the required secret
+    env::set_var("CONFIG_SECRETS_PROVIDER", "vault");
+    env::set_var("VAULT_ADDR", format!("file://{}", vault_dir.display()));
+
+    let config_manager = config_loader::ConfigManager::with_dirs(contracts_dir, config_dir);
+    let router = Router::with_config_manager(config_manager);
+
+    // This should fail due to missing secret
+    let result = router
+        .dispatch(
+            "echo",
+            &serde_json::json!({"message": "test"}),
+            "test-run",
+            "test-ritual",
+        )
+        .await;
+
+    assert!(result.is_err());
+    assert!(result
+        .unwrap_err()
+        .to_string()
+        .contains("Configuration validation failed"));
+
+    // Clean up
+    env::remove_var("CONFIG_SECRETS_PROVIDER");
+    env::remove_var("VAULT_ADDR");
+}
+
+#[tokio::test]
+async fn test_router_succeeds_with_vault_secret_resolution() {
+    let temp_dir = TempDir::new().unwrap();
+    let contracts_dir = temp_dir.path().join("contracts");
+    let config_dir = temp_dir.path().join("config");
+    let vault_dir = temp_dir.path().join("vault");
+
+    // Create test directories
+    fs::create_dir_all(contracts_dir.join("config")).unwrap();
+    fs::create_dir_all(&config_dir).unwrap();
+    fs::create_dir_all(&vault_dir).unwrap();
+
+    // Create echo schema
+    let schema_content = r#"{
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+            "messagePrefix": { "type": "string", "default": "" },
+            "enableTrim": { "type": "boolean", "default": true },
+            "apiKey": { "type": "string" }
+        },
+        "required": ["messagePrefix", "enableTrim", "apiKey"],
+        "additionalProperties": false
+    }"#;
+
+    fs::write(
+        contracts_dir.join("config/echo-config.v1.json"),
+        schema_content,
+    )
+    .unwrap();
+
+    // Create config with secret reference
+    let config_content = r#"{
+        "messagePrefix": "Test: ",
+        "enableTrim": true,
+        "apiKey": "secret://api/key"
+    }"#;
+
+    fs::write(config_dir.join("echo.json"), config_content).unwrap();
+
+    // Set up vault provider and store the required secret
+    env::set_var("CONFIG_SECRETS_PROVIDER", "vault");
+    env::set_var("VAULT_ADDR", format!("file://{}", vault_dir.display()));
+
+    let vault_provider = VaultStubProvider::from_env().unwrap();
+    vault_provider.put("api", "key", "test-api-key").unwrap();
+
+    let config_manager = config_loader::ConfigManager::with_dirs(contracts_dir, config_dir);
+    let router = Router::with_config_manager(config_manager);
+
+    // This should succeed with the secret resolved
+    let result = router
+        .dispatch(
+            "echo",
+            &serde_json::json!({"message": "test"}),
+            "test-run",
+            "test-ritual",
+        )
+        .await;
+
+    assert!(result.is_ok());
+
+    // Clean up
+    env::remove_var("CONFIG_SECRETS_PROVIDER");
+    env::remove_var("VAULT_ADDR");
+}
+
+#[test]
+fn test_vault_stub_file_operations() {
+    let temp_dir = TempDir::new().unwrap();
+    let vault_addr = format!("file://{}", temp_dir.path().display());
+
+    let provider = VaultStubProvider::new(Some(vault_addr), None).unwrap();
+
+    // Test put and resolve
+    provider.put("test", "key1", "value1").unwrap();
+    provider.put("test", "key2", "value2").unwrap();
+    provider.put("other", "key1", "other-value").unwrap();
+
+    assert_eq!(provider.resolve("test", "key1").unwrap(), "value1");
+    assert_eq!(provider.resolve("test", "key2").unwrap(), "value2");
+    assert_eq!(provider.resolve("other", "key1").unwrap(), "other-value");
+
+    // Test list functionality
+    let all_secrets = provider.list(None).unwrap();
+    assert_eq!(all_secrets.len(), 2);
+    assert!(all_secrets.contains_key("test"));
+    assert!(all_secrets.contains_key("other"));
+
+    // Test scope filtering
+    let test_secrets = provider.list(Some("test")).unwrap();
+    assert_eq!(test_secrets.len(), 1);
+    assert!(test_secrets.contains_key("test"));
+    assert_eq!(test_secrets["test"].len(), 2);
+
+    // Test delete
+    provider.delete("test", "key1").unwrap();
+    assert!(provider.resolve("test", "key1").is_err());
+    assert_eq!(provider.resolve("test", "key2").unwrap(), "value2");
+
+    // Delete all keys in scope - scope should be removed
+    provider.delete("test", "key2").unwrap();
+    let remaining_secrets = provider.list(None).unwrap();
+    assert_eq!(remaining_secrets.len(), 1);
+    assert!(remaining_secrets.contains_key("other"));
+}
+
+#[test]
+fn test_vault_stub_invalid_configurations() {
+    // Test invalid vault addr
+    let result = VaultStubProvider::new(Some("invalid://protocol".to_string()), None);
+    assert!(result.is_err());
+
+    // Test missing env vars
+    env::remove_var("VAULT_ADDR");
+    env::remove_var("VAULT_TOKEN");
+
+    let provider = VaultStubProvider::from_env().unwrap();
+    // Should default to file://vault_stub under home dir
+    drop(provider);
+}
+
+#[test]
+fn test_vault_stub_permission_handling() {
+    let temp_dir = TempDir::new().unwrap();
+    let vault_addr = format!("file://{}", temp_dir.path().display());
+
+    let provider = VaultStubProvider::new(Some(vault_addr), None).unwrap();
+
+    provider
+        .put("secure", "password", "very-secret-password")
+        .unwrap();
+
+    // On Unix systems, check that the file has proper permissions
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let scope_file = temp_dir.path().join("secure.json");
+        if scope_file.exists() {
+            let metadata = fs::metadata(&scope_file).unwrap();
+            let permissions = metadata.permissions().mode() & 0o777;
+            assert_eq!(
+                permissions, 0o600,
+                "Vault stub files should have 600 permissions"
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add SecretProviderFactory allowing 'envfile' or 'vault' provider
- Implement VaultStubProvider with env/file backing for testing
- Wire runtime & CLI to choose provider based on CONFIG_SECRETS_PROVIDER/env
- Update docs with provider selection instructions

## Security Fix
- Add scope validation to prevent directory traversal attacks in VaultStubProvider
- Only allow alphanumeric characters, hyphens, and underscores in scope names
- Reject dangerous patterns like '../', '.ssh', '/etc/passwd'

## Testing
- cargo fmt
- cargo clippy --workspace --all-features -- -D warnings
- cargo test --workspace --all-features -- --nocapture
- demonctl secrets set/get/list --provider vault
- runtime smoke with CONFIG_SECRETS_PROVIDER=vault

Fixes #148

Review-lock: 3f9fa7fe515dbf15353da62f97914aa39465f7f1