### PR TITLE
fix(engine): add missing cancel counter reset in test

### DIFF
--- a/engine/tests/approvals_ttl_spec.rs
+++ b/engine/tests/approvals_ttl_spec.rs
@@ -111,6 +111,7 @@ fn cancel_prevents_fire_without_sleep() {
     let run = "run-ttl-4";
     let ritual = "ritual-ttl";
     let gate = "g-4";
+    engine::rituals::timers::reset_cancel_counter();
     let key = engine::rituals::approvals::expiry_key(run, gate);
 
     let mut wheel = engine::rituals::timers::TimerWheel::new_with_time(t0);


### PR DESCRIPTION
## Summary
- Fixes failing CI test `terminal_preempts_and_cancels_counter`
- Adds missing `reset_cancel_counter()` call in the preceding test
- Resolves test isolation issue that was causing CI failures

## Background
The CI was failing on the main branch because of a test isolation issue in `engine/tests/approvals_ttl_spec.rs`. The test `cancel_prevents_fire_without_sleep` was calling `cancel_by_key()` which increments a global counter, but didn't reset the counter before the test. This caused the subsequent `terminal_preempts_and_cancels_counter` test to see a counter value of 2 instead of 1.

## Test plan
- [x] Local test run passes: `cargo test -p engine --test approvals_ttl_spec`
- [x] Full test suite passes: `make test`

Fixes blocking issue for Epic #121 contracts release.

🤖 Generated with [Claude Code](https://claude.ai/code)