### PR TITLE
fix: add missing if condition to review-threads-guard check step

### DIFF
--- a/.github/workflows/review-threads-guard.yml
+++ b/.github/workflows/review-threads-guard.yml
@@ -66,6 +66,7 @@ jobs:
           exit 0
 
       - name: Check unresolved threads (no author reply)
+        if: steps.decide.outputs.enforce == 'true' && steps.decide.outputs.docsonly != 'true'
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
Fixes Bug #133 by adding the missing `if` condition to the "Check unresolved threads" step in the review-threads-guard workflow.

## Problem
The review-threads-guard workflow was running the actual check step unconditionally, even when:
- The `enforce-review-replies` label was absent (enforcement disabled)
- The PR contained only docs-only changes (should be exempt)

This caused failures on PRs that shouldn't be subject to the guard, blocking merges incorrectly.

## Solution
Added the missing `if` condition to the "Check unresolved threads" step:
```yaml
if: steps.decide.outputs.enforce == 'true' && steps.decide.outputs.docsonly != 'true'
```

This ensures the guard check only runs when both:
- Enforcement is enabled (`enforce-review-replies` label present)
- The change is not docs-only

## Test Plan
- [x] `make fmt` - formatting passes
- [x] `make lint` - linting passes
- [x] Workflow step now properly respects existing short-circuit logic
- [x] Test with PR without `enforce-review-replies` label (passes without running check)
- [ ] Test with PR with `enforce-review-replies` label (should run check as before)

## Impact
The workflow now correctly short-circuits when enforcement is not enabled, preventing false failures on PRs that shouldn't be subject to review thread checking.

Fixes #133

Review-lock: cf14a205064a128ac93e7f9a81108338f25b5b99