### PR TITLE
feat(docker): establish image pipeline for runtime/engine/ui

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,80 @@
+# Git
+.git
+.gitignore
+
+# Build artifacts
+target/
+dist/
+.cargo/
+
+# Dependencies
+node_modules/
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Logs
+*.log
+logs/
+
+# Test results
+test-results/
+.pytest_cache/
+
+# Local environment
+.env
+.env.local
+.env.*.local
+
+# Documentation
+docs/
+*.md
+CHANGELOG.md
+CONTRIBUTING.md
+README.md
+
+# Scripts and tools
+scripts/
+tooling/
+audit-*.sh
+
+# Temporary files
+temp.md
+tmux-*.log
+assistant_*
+
+# CI/CD
+.github/
+.ci-nudge
+
+# Runtime data
+.demon/
+k8s-bootstrapper-smoke-*/
+
+# Package lock files (we copy these explicitly when needed)
+package-lock.json
+yarn.lock
+
+# Examples and tests that aren't needed for builds
+examples/
+**/tests/
+**/test/
+
+# Build configuration files we don't need
+deny.toml
+Makefile
+PR_*.txt
+
+# Large directories we don't need for builds
+dist/
+target/
+.demon/
+k8s-bootstrapper-smoke-*/
+20250923-*/

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -25,7 +25,9 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
+    name: Build ${{ matrix.component }}
     strategy:
+      fail-fast: false
       matrix:
         component: [operate-ui, runtime, engine]
 
@@ -37,8 +39,13 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          driver-opts: network=host
 
       - name: Log in to Container Registry
         if: github.event_name != 'pull_request'
@@ -56,10 +63,11 @@ jobs:
           tags: |
             type=ref,event=branch
             type=ref,event=pr
-            type=sha,prefix={{branch}}-
+            type=sha,prefix=sha-
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push Docker image
+        id: build
         uses: docker/build-push-action@v5
         with:
           context: .
@@ -67,11 +75,18 @@ jobs:
           push: ${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/main' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=${{ matrix.component }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.component }}
+          platforms: linux/amd64,linux/arm64
 
       - name: Output image metadata
+        if: always()
         run: |
+          echo "Component: ${{ matrix.component }}"
           echo "Image: ${{ env.IMAGE_PREFIX }}-${{ matrix.component }}"
           echo "Tags: ${{ steps.meta.outputs.tags }}"
           echo "Digest: ${{ steps.build.outputs.digest }}"
+          echo "Build Cache Key: ${{ matrix.component }}"
+          if [ "${{ steps.build.outcome }}" = "failure" ]; then
+            echo "::error title=Docker Build Failed::Failed to build ${{ matrix.component }} image"
+          fi

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,77 @@
+name: Build and Push Docker Images
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    paths:
+      - '**/Dockerfile'
+      - '**/src/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'rust-toolchain.toml'
+      - 'operate-ui/**'
+      - 'runtime/**'
+      - 'engine/**'
+      - 'crates/**'
+      - 'wards/**'
+      - 'capsules/**'
+  workflow_dispatch: {}
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_PREFIX: ghcr.io/afewell-hh/demon
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        component: [operate-ui, runtime, engine]
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE_PREFIX }}-${{ matrix.component }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=sha,prefix={{branch}}-
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./${{ matrix.component }}/Dockerfile
+          push: ${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/main' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Output image metadata
+        run: |
+          echo "Image: ${{ env.IMAGE_PREFIX }}-${{ matrix.component }}"
+          echo "Tags: ${{ steps.meta.outputs.tags }}"
+          echo "Digest: ${{ steps.build.outputs.digest }}"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2764,6 +2764,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/engine/.dockerignore
+++ b/engine/.dockerignore
@@ -1,0 +1,9 @@
+# Test files
+tests/
+test-results/
+
+# Build artifacts
+target/
+
+# Documentation
+docs/

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -5,12 +5,17 @@ edition.workspace = true
 license.workspace = true
 authors.workspace = true
 
+[[bin]]
+name = "engine"
+path = "src/main.rs"
+
 [dependencies]
 anyhow = { workspace = true }
 serde = { workspace = true }
 serde_yaml = { workspace = true }
 serde_json = { workspace = true }
 tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
 uuid = { workspace = true }
 chrono = { workspace = true }
 runtime = { path = "../runtime" }
@@ -19,7 +24,6 @@ async-nats = { workspace = true }
 tokio = { workspace = true }
 futures-util = { workspace = true }
 wards = { path = "../wards" }
-tracing-subscriber = { workspace = true }
 
 [dev-dependencies]
 jsonschema = { workspace = true }

--- a/engine/Dockerfile
+++ b/engine/Dockerfile
@@ -1,0 +1,43 @@
+# Multi-stage build for engine
+FROM rust:1.77-alpine AS builder
+
+# Install build dependencies
+RUN apk add --no-cache musl-dev openssl-dev openssl-libs-static
+
+WORKDIR /app
+
+# Copy workspace files
+COPY Cargo.toml Cargo.lock ./
+COPY rust-toolchain.toml ./
+
+# Copy all workspace members and contracts (needed for dependencies)
+COPY crates/ ./crates/
+COPY contracts/ ./contracts/
+COPY runtime/ ./runtime/
+COPY engine/ ./engine/
+COPY operate-ui/ ./operate-ui/
+COPY wards/ ./wards/
+COPY capsules/ ./capsules/
+COPY demonctl/ ./demonctl/
+COPY bootstrapper/ ./bootstrapper/
+
+# Set build target for static linking
+ENV RUSTFLAGS="-C target-feature=-crt-static"
+
+# Build the engine binary
+RUN cargo build --release --bin engine
+
+# Runtime stage
+FROM gcr.io/distroless/cc-debian12
+
+# Copy the binary
+COPY --from=builder /app/target/release/engine /usr/local/bin/engine
+
+# Expose port
+EXPOSE 8081
+
+# Run as non-root
+USER nonroot:nonroot
+
+# Start the application
+CMD ["engine"]

--- a/engine/src/main.rs
+++ b/engine/src/main.rs
@@ -1,0 +1,62 @@
+use anyhow::Result;
+use std::env;
+use tokio::net::TcpListener;
+use tracing::{info, warn};
+use tracing_subscriber::EnvFilter;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    // Initialize tracing
+    tracing_subscriber::fmt()
+        .with_env_filter(EnvFilter::from_default_env())
+        .init();
+
+    let port = env::var("PORT").unwrap_or_else(|_| "8081".to_string());
+    let addr = format!("0.0.0.0:{}", port);
+
+    info!("Starting Demon Engine on {}", addr);
+
+    let listener = TcpListener::bind(&addr).await?;
+    info!("Engine server listening on {}", addr);
+
+    loop {
+        match listener.accept().await {
+            Ok((mut stream, addr)) => {
+                info!("Connection from {}", addr);
+                tokio::spawn(async move {
+                    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+                    let mut buffer = [0; 1024];
+                    match stream.read(&mut buffer).await {
+                        Ok(0) => {
+                            info!("Connection closed by client");
+                        }
+                        Ok(n) => {
+                            let request = String::from_utf8_lossy(&buffer[..n]);
+                            info!("Received request: {}", request.lines().next().unwrap_or(""));
+
+                            // Simple HTTP response for health checks
+                            let response = if request.contains("GET /health") {
+                                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 15\r\n\r\n{\"status\":\"ok\"}"
+                            } else if request.contains("GET /ready") {
+                                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 17\r\n\r\n{\"ready\":true}"
+                            } else {
+                                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 27\r\n\r\n{\"service\":\"demon-engine\"}"
+                            };
+
+                            if let Err(e) = stream.write_all(response.as_bytes()).await {
+                                warn!("Failed to write response: {}", e);
+                            }
+                        }
+                        Err(e) => {
+                            warn!("Failed to read from stream: {}", e);
+                        }
+                    }
+                });
+            }
+            Err(e) => {
+                warn!("Failed to accept connection: {}", e);
+            }
+        }
+    }
+}

--- a/operate-ui/.dockerignore
+++ b/operate-ui/.dockerignore
@@ -1,0 +1,13 @@
+# Test files
+tests/
+test-results/
+playwright/
+
+# Node modules (if any)
+node_modules/
+
+# Build artifacts
+target/
+
+# Documentation
+docs/

--- a/operate-ui/Dockerfile
+++ b/operate-ui/Dockerfile
@@ -1,0 +1,50 @@
+# Multi-stage build for operate-ui
+FROM rust:1.77-alpine AS builder
+
+# Install build dependencies
+RUN apk add --no-cache musl-dev openssl-dev openssl-libs-static
+
+WORKDIR /app
+
+# Copy workspace files
+COPY Cargo.toml Cargo.lock ./
+COPY rust-toolchain.toml ./
+
+# Copy all workspace members and contracts (needed for dependencies)
+COPY crates/ ./crates/
+COPY contracts/ ./contracts/
+COPY runtime/ ./runtime/
+COPY engine/ ./engine/
+COPY operate-ui/ ./operate-ui/
+COPY wards/ ./wards/
+COPY capsules/ ./capsules/
+COPY demonctl/ ./demonctl/
+COPY bootstrapper/ ./bootstrapper/
+
+# Set build target for static linking
+ENV RUSTFLAGS="-C target-feature=-crt-static"
+
+# Build the operate-ui binary
+RUN cargo build --release --bin operate-ui
+
+# Runtime stage
+FROM gcr.io/distroless/cc-debian12
+
+# Copy static files
+COPY operate-ui/templates /app/templates
+COPY operate-ui/static /app/static
+
+# Copy the binary
+COPY --from=builder /app/target/release/operate-ui /usr/local/bin/operate-ui
+
+# Set working directory
+WORKDIR /app
+
+# Expose port
+EXPOSE 3000
+
+# Run as non-root
+USER nonroot:nonroot
+
+# Start the application
+CMD ["operate-ui"]

--- a/operate-ui/Dockerfile
+++ b/operate-ui/Dockerfile
@@ -30,9 +30,8 @@ RUN cargo build --release --bin operate-ui
 # Runtime stage
 FROM gcr.io/distroless/cc-debian12
 
-# Copy static files
-COPY operate-ui/templates /app/templates
-COPY operate-ui/static /app/static
+# Copy template files
+COPY --from=builder /app/operate-ui/templates /app/templates
 
 # Copy the binary
 COPY --from=builder /app/target/release/operate-ui /usr/local/bin/operate-ui

--- a/runtime/.dockerignore
+++ b/runtime/.dockerignore
@@ -1,0 +1,9 @@
+# Test files
+tests/
+test-results/
+
+# Build artifacts
+target/
+
+# Documentation
+docs/

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -5,6 +5,10 @@ edition.workspace = true
 license.workspace = true
 authors.workspace = true
 
+[[bin]]
+name = "runtime"
+path = "src/main.rs"
+
 [dependencies]
 anyhow = { workspace = true }
 envelope = { path = "../crates/envelope" }
@@ -13,6 +17,7 @@ once_cell = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
 capsules_echo = { path = "../capsules/echo" }
 async-nats = { workspace = true }
 tokio = { workspace = true }

--- a/runtime/Dockerfile
+++ b/runtime/Dockerfile
@@ -1,0 +1,43 @@
+# Multi-stage build for runtime
+FROM rust:1.77-alpine AS builder
+
+# Install build dependencies
+RUN apk add --no-cache musl-dev openssl-dev openssl-libs-static
+
+WORKDIR /app
+
+# Copy workspace files
+COPY Cargo.toml Cargo.lock ./
+COPY rust-toolchain.toml ./
+
+# Copy all workspace members and contracts (needed for dependencies)
+COPY crates/ ./crates/
+COPY contracts/ ./contracts/
+COPY runtime/ ./runtime/
+COPY engine/ ./engine/
+COPY operate-ui/ ./operate-ui/
+COPY wards/ ./wards/
+COPY capsules/ ./capsules/
+COPY demonctl/ ./demonctl/
+COPY bootstrapper/ ./bootstrapper/
+
+# Set build target for static linking
+ENV RUSTFLAGS="-C target-feature=-crt-static"
+
+# Build the runtime binary
+RUN cargo build --release --bin runtime
+
+# Runtime stage
+FROM gcr.io/distroless/cc-debian12
+
+# Copy the binary
+COPY --from=builder /app/target/release/runtime /usr/local/bin/runtime
+
+# Expose port
+EXPOSE 8080
+
+# Run as non-root
+USER nonroot:nonroot
+
+# Start the application
+CMD ["runtime"]

--- a/runtime/src/main.rs
+++ b/runtime/src/main.rs
@@ -1,0 +1,62 @@
+use anyhow::Result;
+use std::env;
+use tokio::net::TcpListener;
+use tracing::{info, warn};
+use tracing_subscriber::EnvFilter;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    // Initialize tracing
+    tracing_subscriber::fmt()
+        .with_env_filter(EnvFilter::from_default_env())
+        .init();
+
+    let port = env::var("PORT").unwrap_or_else(|_| "8080".to_string());
+    let addr = format!("0.0.0.0:{}", port);
+
+    info!("Starting Demon Runtime on {}", addr);
+
+    let listener = TcpListener::bind(&addr).await?;
+    info!("Runtime server listening on {}", addr);
+
+    loop {
+        match listener.accept().await {
+            Ok((mut stream, addr)) => {
+                info!("Connection from {}", addr);
+                tokio::spawn(async move {
+                    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+                    let mut buffer = [0; 1024];
+                    match stream.read(&mut buffer).await {
+                        Ok(0) => {
+                            info!("Connection closed by client");
+                        }
+                        Ok(n) => {
+                            let request = String::from_utf8_lossy(&buffer[..n]);
+                            info!("Received request: {}", request.lines().next().unwrap_or(""));
+
+                            // Simple HTTP response for health checks
+                            let response = if request.contains("GET /health") {
+                                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 15\r\n\r\n{\"status\":\"ok\"}"
+                            } else if request.contains("GET /ready") {
+                                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 17\r\n\r\n{\"ready\":true}"
+                            } else {
+                                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 29\r\n\r\n{\"service\":\"demon-runtime\"}"
+                            };
+
+                            if let Err(e) = stream.write_all(response.as_bytes()).await {
+                                warn!("Failed to write response: {}", e);
+                            }
+                        }
+                        Err(e) => {
+                            warn!("Failed to read from stream: {}", e);
+                        }
+                    }
+                });
+            }
+            Err(e) => {
+                warn!("Failed to accept connection: {}", e);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #181 #182

## Summary
- Add Dockerfiles for operate-ui, runtime, and engine using multi-stage builds.
- Introduce `.dockerignore` files and a Docker build workflow that builds/pushes to GHCR.
- Add standalone HTTP binaries for runtime (8080) and engine (8081) with health endpoints to support Docker images.

## Test Plan
- [x] make fmt
- [x] make lint
- [x] make test   # note existing unrelated failure if still present

Review-lock: 70e34886fa8a6aa9c267cc58249d4640144f26b2