### PR TITLE
🚨 HOTFIX: Remove ARM64 platform to fix Docker CI failures

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -77,7 +77,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha,scope=${{ matrix.component }}
           cache-to: type=gha,mode=max,scope=${{ matrix.component }}
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
 
       - name: Output image metadata
         if: always()


### PR DESCRIPTION
## 🚨 CRITICAL HOTFIX

**Issue**: Docker builds failing in CI due to ARM64 cross-compilation errors, preventing static musl images from being published.

**Root Cause**: ARM64 builder trying to cross-compile to `x86_64-unknown-linux-musl` target fails with:
```
error[E0463]: can't find crate for `core`
= note: the `x86_64-unknown-linux-musl` target may not be installed
```

**Impact**: 
- ❌ No new Docker images published to GHCR since PR #191 merge
- ❌ K8s pods still pulling old broken images  
- ❌ CrashLoopBackOff continues in nightly smoke tests

**Fix**: Temporarily remove `linux/arm64` platform from CI builds to publish AMD64 images immediately.

**Validation**: Once merged, this will trigger Docker CI to publish static musl images, resolving CrashLoopBackOff.

**Next Steps**: Follow up with proper ARM64 cross-compilation configuration.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>

Review-lock: 8fac97bef7a351f64e0be31ed4e5cbd54fbf9941