### PR TITLE
contracts: add graph schemas and WIT interface

### DIFF
--- a/contracts/fixtures/events/graph.commit.created.v1.json
+++ b/contracts/fixtures/events/graph.commit.created.v1.json
@@ -1,0 +1,67 @@
+{
+  "event": "graph.commit.created:v1",
+  "graphId": "knowledge-base",
+  "tenantId": "tenant-01",
+  "projectId": "atlas",
+  "namespace": "support",
+  "commitId": "4a7c2f8d0b9e3f5c1a2b3c4d5e6f708192a3b4c5d6e7f8091a2b3c4d5e6f7081",
+  "parentCommitId": "0f1e2d3c4b5a69788776655443322110ffeeddccbbaa99887766554433221100",
+  "ts": "2025-03-17T12:34:56Z",
+  "mutations": [
+    {
+      "op": "add-node",
+      "nodeId": "article.root",
+      "labels": ["Article", "Root"],
+      "properties": {
+        "title": "Graph Home",
+        "status": "published"
+      }
+    },
+    {
+      "op": "add-node",
+      "nodeId": "article.search",
+      "labels": ["Article"],
+      "properties": {
+        "title": "Search Tips",
+        "status": "draft"
+      }
+    },
+    {
+      "op": "add-edge",
+      "edgeId": "rel.root-search",
+      "from": "article.root",
+      "to": "article.search",
+      "label": "related",
+      "properties": {
+        "weight": 0.8
+      }
+    },
+    {
+      "op": "update-node",
+      "nodeId": "article.search",
+      "labels": ["Article", "Guide"],
+      "properties": {
+        "title": "Search Tips",
+        "status": "published"
+      }
+    },
+    {
+      "op": "update-edge",
+      "edgeId": "rel.root-search",
+      "from": "article.root",
+      "to": "article.search",
+      "label": "linked",
+      "properties": {
+        "weight": 0.9
+      }
+    },
+    {
+      "op": "remove-edge",
+      "edgeId": "rel.legacy-link"
+    }
+  ],
+  "metadata": {
+    "author": "api-user@example.com",
+    "message": "Seeded support graph with search guidance"
+  }
+}

--- a/contracts/fixtures/events/graph.tag.updated.v1.json
+++ b/contracts/fixtures/events/graph.tag.updated.v1.json
@@ -1,0 +1,28 @@
+[
+  {
+    "event": "graph.tag.updated:v1",
+    "graphId": "knowledge-base",
+    "tenantId": "tenant-01",
+    "projectId": "atlas",
+    "namespace": "support",
+    "tag": "production",
+    "ts": "2025-03-17T12:35:10Z",
+    "action": "set",
+    "commitId": "4a7c2f8d0b9e3f5c1a2b3c4d5e6f708192a3b4c5d6e7f8091a2b3c4d5e6f7081",
+    "previousCommitId": "0f1e2d3c4b5a69788776655443322110ffeeddccbbaa99887766554433221100",
+    "actor": {
+      "id": "svc-deployer",
+      "displayName": "Graph Release Bot"
+    }
+  },
+  {
+    "event": "graph.tag.updated:v1",
+    "graphId": "knowledge-base",
+    "tenantId": "tenant-01",
+    "projectId": "atlas",
+    "namespace": "support",
+    "tag": "staging",
+    "ts": "2025-03-17T12:35:45Z",
+    "action": "delete"
+  }
+]

--- a/contracts/schemas/events.graph.commit.created.v1.json
+++ b/contracts/schemas/events.graph.commit.created.v1.json
@@ -1,0 +1,119 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://demon.meta/contracts/events.graph.commit.created.v1.json",
+  "title": "GraphCommitCreatedV1",
+  "type": "object",
+  "required": [
+    "event",
+    "graphId",
+    "tenantId",
+    "projectId",
+    "namespace",
+    "commitId",
+    "ts",
+    "mutations"
+  ],
+  "properties": {
+    "event": { "const": "graph.commit.created:v1" },
+    "graphId": { "$ref": "#/$defs/identifier" },
+    "tenantId": { "$ref": "#/$defs/identifier" },
+    "projectId": { "$ref": "#/$defs/identifier" },
+    "namespace": { "$ref": "#/$defs/identifier" },
+    "commitId": { "$ref": "#/$defs/commit-identifier" },
+    "parentCommitId": { "$ref": "#/$defs/commit-identifier" },
+    "ts": { "type": "string", "format": "date-time" },
+    "mutations": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["op"],
+        "properties": {
+          "op": {
+            "type": "string",
+            "enum": [
+              "add-node",
+              "update-node",
+              "remove-node",
+              "add-edge",
+              "update-edge",
+              "remove-edge"
+            ]
+          },
+          "nodeId": { "$ref": "#/$defs/identifier" },
+          "labels": {
+            "type": "array",
+            "items": { "$ref": "#/$defs/label" }
+          },
+          "properties": { "$ref": "#/$defs/properties" },
+          "edgeId": { "$ref": "#/$defs/identifier" },
+          "from": { "$ref": "#/$defs/identifier" },
+          "to": { "$ref": "#/$defs/identifier" },
+          "label": { "$ref": "#/$defs/label" }
+        },
+        "additionalProperties": false,
+        "allOf": [
+          {
+            "if": {
+              "properties": { "op": { "enum": ["add-node", "update-node", "remove-node"] } }
+            },
+            "then": { "required": ["nodeId"] }
+          },
+          {
+            "if": {
+              "properties": { "op": { "enum": ["add-node", "update-node"] } }
+            },
+            "then": {
+              "properties": {
+                "labels": {
+                  "type": "array",
+                  "items": { "$ref": "#/$defs/label" }
+                },
+                "properties": { "$ref": "#/$defs/properties" }
+              }
+            }
+          },
+          {
+            "if": {
+              "properties": { "op": { "enum": ["add-edge", "update-edge", "remove-edge"] } }
+            },
+            "then": { "required": ["edgeId"] }
+          },
+          {
+            "if": {
+              "properties": { "op": { "enum": ["add-edge", "update-edge"] } }
+            },
+            "then": {
+              "required": ["from", "to"],
+              "properties": {
+                "label": { "$ref": "#/$defs/label" },
+                "properties": { "$ref": "#/$defs/properties" }
+              }
+            }
+          }
+        ]
+      }
+    },
+    "metadata": { "type": "object" }
+  },
+  "additionalProperties": false,
+  "$defs": {
+    "identifier": {
+      "type": "string",
+      "pattern": "^[a-zA-Z0-9._-]{1,64}$"
+    },
+    "commit-identifier": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{64}$"
+    },
+    "label": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 64
+    },
+    "properties": {
+      "type": "object",
+      "additionalProperties": true
+    }
+  }
+}

--- a/contracts/schemas/events.graph.tag.updated.v1.json
+++ b/contracts/schemas/events.graph.tag.updated.v1.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://demon.meta/contracts/events.graph.tag.updated.v1.json",
+  "title": "GraphTagUpdatedV1",
+  "type": "object",
+  "required": [
+    "event",
+    "graphId",
+    "tenantId",
+    "projectId",
+    "namespace",
+    "tag",
+    "ts",
+    "action"
+  ],
+  "properties": {
+    "event": { "const": "graph.tag.updated:v1" },
+    "graphId": { "$ref": "#/$defs/identifier" },
+    "tenantId": { "$ref": "#/$defs/identifier" },
+    "projectId": { "$ref": "#/$defs/identifier" },
+    "namespace": { "$ref": "#/$defs/identifier" },
+    "tag": { "$ref": "#/$defs/identifier" },
+    "ts": { "type": "string", "format": "date-time" },
+    "action": {
+      "type": "string",
+      "enum": ["set", "delete"]
+    },
+    "commitId": { "$ref": "#/$defs/commit-identifier" },
+    "previousCommitId": { "$ref": "#/$defs/commit-identifier" },
+    "actor": { "type": "object" }
+  },
+  "allOf": [
+    {
+      "if": { "properties": { "action": { "const": "set" } } },
+      "then": { "required": ["commitId"] }
+    }
+  ],
+  "additionalProperties": false,
+  "$defs": {
+    "identifier": {
+      "type": "string",
+      "pattern": "^[a-zA-Z0-9._-]{1,64}$"
+    },
+    "commit-identifier": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{64}$"
+    }
+  }
+}

--- a/contracts/wit/README.md
+++ b/contracts/wit/README.md
@@ -5,6 +5,7 @@ This folder contains WebAssembly Interface Type (WIT) definitions for Demon cont
 ## Available Interfaces
 
 - `demon-envelope.wit` - Result envelope interface with typed bindings for operation results, diagnostics, suggestions, metrics, and provenance
+- `demon-graph.wit` - Graph store interface for commits, queries, and tag management
 
 ## Usage
 

--- a/contracts/wit/demon-graph.wit
+++ b/contracts/wit/demon-graph.wit
@@ -1,0 +1,92 @@
+// Demon Graph Store WIT Interface
+// Defines graph storage operations and supporting types for graph contracts
+// Version: v0.1.0
+
+package demon:graph@0.1.0;
+
+use demon:contracts/demon-envelope.result-envelope;
+
+/// Identifies a graph scope within the Demon platform
+record scope {
+    tenant-id: string,
+    project-id: string,
+    namespace: string,
+    graph-id: string,
+}
+
+/// Key/value pair stored as a JSON encoded property value
+record property {
+    key: string,
+    value: string,
+}
+
+/// Snapshot of a graph node at a commit
+record node-snapshot {
+    node-id: string,
+    labels: list<string>,
+    properties: list<property>,
+}
+
+/// Snapshot of a graph edge at a commit
+record edge-snapshot {
+    edge-id: string,
+    from-node: string,
+    to-node: string,
+    label: option<string>,
+    properties: list<property>,
+}
+
+/// Graph mutation operations applied within a commit
+variant mutation {
+    add-node(node-snapshot),
+    update-node(node-snapshot),
+    remove-node(record { node-id: string }),
+    add-edge(edge-snapshot),
+    update-edge(edge-snapshot),
+    remove-edge(record { edge-id: string }),
+}
+
+/// Result of creating or committing graph changes
+record commit-result {
+    commit-id: string,
+    parent-commit-id: option<string>,
+    envelope: result-envelope.result-envelope,
+}
+
+/// Association between a tag and commit
+record tagged-commit {
+    tag: string,
+    commit-id: string,
+    timestamp: string,
+}
+
+/// Error returned by graph store operations
+record graph-error {
+    code: string,
+    message: string,
+    details: option<string>,
+}
+
+/// Graph storage interface for commit and query operations
+interface graph-store {
+    /// Create a new graph by seeding an initial commit
+    create: func(scope: scope, seed: list<mutation>) -> result<commit-result, graph-error>;
+
+    /// Commit a new set of mutations referencing an optional parent commit
+    commit: func(scope: scope, parent-ref: option<string>, mutations: list<mutation>) -> result<commit-result, graph-error>;
+
+    /// Retrieve a node snapshot for a given commit and node identifier
+    get-node: func(scope: scope, commit-id: string, node-id: string) -> result<option<node-snapshot>, graph-error>;
+
+    /// List neighboring nodes up to the specified depth from the starting node
+    neighbors: func(scope: scope, commit-id: string, node-id: string, depth: u32) -> result<list<node-snapshot>, graph-error>;
+
+    /// Determine whether a path exists between two nodes within the depth constraint
+    path-exists: func(scope: scope, commit-id: string, from: string, to: string, max-depth: u32) -> result<bool, graph-error>;
+
+    /// Attach or update a tag to point at a commit
+    tag: func(scope: scope, tag: string, commit-id: string) -> result<tagged-commit, graph-error>;
+
+    /// List all tags associated with the graph scope
+    list-tags: func(scope: scope) -> result<list<tagged-commit>, graph-error>;
+}

--- a/docs/mvp/02-epics.md
+++ b/docs/mvp/02-epics.md
@@ -3,7 +3,7 @@
 | MVP-E1 | Core Execution & Events | MVP-Alpha  | @afewell-hh | In progress  | issues: #56, #57 |
 | MVP-E2 | Policy & Approval Engine | MVP-Beta  | @afewell-hh | Complete (Sprint 5) | issues: #58, #59, #60; PR: #93 |
 | MVP-E3 | UI & API Interfaces | MVP-Alpha  | @afewell-hh | In progress  | issues: #61, #62 |
-| MVP-E4 | Developer Experience | MVP-Alpha  | @afewell-hh | In progress  | issues: #63 |
+| MVP-E4 | Developer Experience | MVP-Alpha  | @afewell-hh | In progress  | issues: #63; Blocked on story creation (gh --version → command not found) |
 | MVP-E6 | UI Dashboard | MVP-Alpha  | @afewell-hh | Complete (M1-1) | PR: #105 |
 | MVP-E7 | Multi-tenant Foundations | MVP-Alpha  | @afewell-hh | Complete (M1-2) | PR: #107 |
 | MVP-E8 | Advanced Policy Engine | MVP-Alpha  | @afewell-hh | Complete (M1-3) | PRs: #108, #109 |

--- a/docs/personas/api-consumers.md
+++ b/docs/personas/api-consumers.md
@@ -2,6 +2,10 @@
 
 Welcome, API consumers! This guide helps you integrate with Demon's REST APIs, consume event streams, and build applications that interact with the Demon platform.
 
+## Notes
+
+- Story tracking for EPIC-4: Graph contracts foundation is pending because the GitHub CLI is unavailable in this environment (`gh --version` → `command not found`).
+
 ## 🚀 Quick Start
 
 Ready to integrate with Demon? Here's your fast path:


### PR DESCRIPTION
## Summary
- add graph commit and tag event schemas with identifier validation and mutation rules
- provide fixture payloads that cover node and edge mutations plus tag set/delete cases
- introduce the demon-graph WIT interface and document availability along with pending PM tracker note

## Testing
- cargo fmt
- cargo test --workspace --all-features -- --nocapture
- scripts/check-doc-links.sh --quiet *(fails: markdown-link-check is not installed)*

------
https://chatgpt.com/codex/tasks/task_b_68db24889c74832e9acd1bf3fefd5eb7