### PR TITLE
contracts: split graph tag fixtures by action

### DIFF
--- a/contracts/fixtures/events/graph.tag.deleted.v1.json
+++ b/contracts/fixtures/events/graph.tag.deleted.v1.json
@@ -1,0 +1,16 @@
+{
+  "event": "graph.tag.updated:v1",
+  "graphId": "operations/incident-response",
+  "tenantId": "default",
+  "traceId": "trace-graph-tag-delete-001",
+  "ts": "2025-01-10T04:12:00Z",
+  "action": "delete",
+  "tag": {
+    "key": "severity"
+  },
+  "actor": {
+    "type": "system",
+    "id": "operate-ui",
+    "displayName": "Operate UI"
+  }
+}

--- a/contracts/fixtures/events/graph.tag.updated.v1.json
+++ b/contracts/fixtures/events/graph.tag.updated.v1.json
@@ -1,0 +1,18 @@
+{
+  "event": "graph.tag.updated:v1",
+  "graphId": "operations/incident-response",
+  "tenantId": "default",
+  "traceId": "trace-graph-tag-set-001",
+  "ts": "2025-01-06T10:30:00Z",
+  "action": "set",
+  "tag": {
+    "key": "severity",
+    "value": "critical",
+    "note": "Raised automatically when pager triggered"
+  },
+  "actor": {
+    "type": "system",
+    "id": "operate-ui",
+    "displayName": "Operate UI"
+  }
+}

--- a/contracts/schemas/events.graph.tag.updated.v1.json
+++ b/contracts/schemas/events.graph.tag.updated.v1.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://demon.meta/contracts/events.graph.tag.updated.v1.json",
+  "title": "GraphTagUpdatedV1",
+  "type": "object",
+  "required": ["event", "graphId", "action", "tag", "ts"],
+  "properties": {
+    "event": { "const": "graph.tag.updated:v1" },
+    "graphId": { "type": "string" },
+    "tenantId": { "type": "string" },
+    "traceId": { "type": "string" },
+    "ts": { "type": "string", "format": "date-time" },
+    "action": { "type": "string", "enum": ["set", "delete"] },
+    "tag": {
+      "type": "object",
+      "required": ["key"],
+      "properties": {
+        "key": { "type": "string" },
+        "value": { "type": "string" },
+        "note": { "type": "string" }
+      },
+      "additionalProperties": false
+    },
+    "actor": {
+      "type": "object",
+      "required": ["type", "id"],
+      "properties": {
+        "type": { "type": "string" },
+        "id": { "type": "string" },
+        "displayName": { "type": "string" }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false,
+  "allOf": [
+    {
+      "if": { "properties": { "action": { "const": "set" } } },
+      "then": {
+        "properties": {
+          "tag": {
+            "required": ["key", "value"]
+          }
+        }
+      }
+    }
+  ]
+}

--- a/docs/mvp/02-epics.md
+++ b/docs/mvp/02-epics.md
@@ -11,4 +11,4 @@
 | Epic | Title | Outcome | Links |
 |------|-------|---------|-------|
 | MVP-E5 | CI/Protections Simplification | MVP-grade protections documented and enforced without blocking velocity | PRs: #53, #64, #65 |
-| #121 | Contract & Schema Registry | Contract bundles publish via CI, versioned/signed, smoke-verified, fetched by tag, runtime ingestion, UI alerts/metrics | Stories: #124-#140; PRs: #132, #135-#137, #140 |
+| #121 | Contract & Schema Registry | Contract bundles publish via CI, versioned/signed, smoke-verified, fetched by tag, runtime ingestion, UI alerts/metrics | Stories: #124-#140; PRs: #132, #135-#137, #140; Follow-up: Graph tag fixture split noted for PR #199 (gh CLI unavailable for direct comment) |

--- a/engine/tests/graph_contracts_spec.rs
+++ b/engine/tests/graph_contracts_spec.rs
@@ -1,0 +1,47 @@
+use jsonschema::JSONSchema;
+use std::{fs, path::Path};
+
+#[test]
+fn graph_tag_fixtures_validate_against_schema() {
+    let schema_path = "../contracts/schemas/events.graph.tag.updated.v1.json";
+    assert!(Path::new(schema_path).exists(), "missing {schema_path}");
+
+    let schema_text = fs::read_to_string(schema_path).expect(schema_path);
+    if schema_text.trim().is_empty() {
+        eprintln!(
+            "skipping validation for placeholder schema: {}",
+            schema_path
+        );
+        return;
+    }
+
+    let schema = JSONSchema::compile(&serde_json::from_str(&schema_text).expect("parse schema"))
+        .expect("schema compiles");
+
+    for fixture_path in [
+        "../contracts/fixtures/events/graph.tag.updated.v1.json",
+        "../contracts/fixtures/events/graph.tag.deleted.v1.json",
+    ] {
+        assert!(Path::new(fixture_path).exists(), "missing {fixture_path}");
+
+        let fixture_text = fs::read_to_string(fixture_path).expect(fixture_path);
+        if fixture_text.trim().is_empty() {
+            eprintln!(
+                "skipping validation for placeholder fixture: {}",
+                fixture_path
+            );
+            continue;
+        }
+
+        let instance: serde_json::Value =
+            serde_json::from_str(&fixture_text).expect("parse fixture");
+
+        assert!(
+            schema.validate(&instance).is_ok(),
+            "fixture {} should validate against schema {}. Validation errors: {:?}",
+            fixture_path,
+            schema_path,
+            schema.validate(&instance).unwrap_err().collect::<Vec<_>>()
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- add graph tag fixture coverage for separate set/delete examples and align the schema with a single-event payload
- exercise the new fixtures in engine contract validation tests and record the PR #199 follow-up in the MVP epic log

## Testing
- cargo fmt
- cargo test --workspace --all-features -- --nocapture
- scripts/check-doc-links.sh --quiet *(fails: markdown-link-check not installed)*

------
https://chatgpt.com/codex/tasks/task_b_68db359c4a68832e8e05fd2ce586ed3a