### PR TITLE
tests: serialize secrets env cases

### DIFF
--- a/demonctl/src/k8s_bootstrap/secrets.rs
+++ b/demonctl/src/k8s_bootstrap/secrets.rs
@@ -280,9 +280,16 @@ pub fn create_image_pull_secrets(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::{Mutex, OnceLock};
+
+    fn env_lock() -> &'static Mutex<()> {
+        static ENV_MUTEX: OnceLock<Mutex<()>> = OnceLock::new();
+        ENV_MUTEX.get_or_init(|| Mutex::new(()))
+    }
 
     #[test]
     fn test_collect_secrets_env_provider() {
+        let _guard = env_lock().lock().unwrap();
         // Set up test environment variables
         env::set_var("TEST_SECRET_1", "value1");
         env::set_var("TEST_SECRET_2", "value2");
@@ -369,6 +376,7 @@ mod tests {
 
     #[test]
     fn test_validate_vault_config_missing_address() {
+        let _guard = env_lock().lock().unwrap();
         env::remove_var("VAULT_ADDR");
         env::remove_var("VAULT_TOKEN");
 
@@ -386,6 +394,7 @@ mod tests {
 
     #[test]
     fn test_validate_vault_config_with_env_vars() {
+        let _guard = env_lock().lock().unwrap();
         env::set_var("VAULT_ADDR", "http://localhost:8200");
         env::set_var("VAULT_TOKEN", "test-token");
 

--- a/docs/mvp/02-epics.md
+++ b/docs/mvp/02-epics.md
@@ -12,3 +12,5 @@
 |------|-------|---------|-------|
 | MVP-E5 | CI/Protections Simplification | MVP-grade protections documented and enforced without blocking velocity | PRs: #53, #64, #65 |
 | #121 | Contract & Schema Registry | Contract bundles publish via CI, versioned/signed, smoke-verified, fetched by tag, runtime ingestion, UI alerts/metrics | Stories: #124-#140; PRs: #132, #135-#137, #140 |
+
+- PR #203: env-lock fix for `k8s_bootstrap::secrets` env-var tests applied locally; awaiting CI confirmation.


### PR DESCRIPTION
## Summary
- guard secrets tests that mutate environment variables with a shared mutex
- acquire the guard in VAULT-related tests to prevent parallel interference

## Testing
- cargo fmt
- cargo test --workspace --all-features -- --nocapture
- ./scripts/check-doc-links.sh --quiet
- scripts/contracts-validate.sh *(missing script in repo)*

------
https://chatgpt.com/codex/tasks/task_b_68db4e736c30832ea84f1b0ed5f4ed73

Review-lock: 535770e38001934b48557032b861d7ca5ed3c05b