### PR TITLE
tests: serialize secrets env cases

### DIFF
--- a/demonctl/src/k8s_bootstrap/secrets.rs
+++ b/demonctl/src/k8s_bootstrap/secrets.rs
@@ -280,9 +280,17 @@ pub fn create_image_pull_secrets(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::{Mutex, OnceLock};
+
+    fn env_lock() -> &'static Mutex<()> {
+        static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        ENV_LOCK.get_or_init(|| Mutex::new(()))
+    }
 
     #[test]
     fn test_collect_secrets_env_provider() {
+        let _guard = env_lock().lock().unwrap();
+
         // Set up test environment variables
         env::set_var("TEST_SECRET_1", "value1");
         env::set_var("TEST_SECRET_2", "value2");
@@ -369,6 +377,8 @@ mod tests {
 
     #[test]
     fn test_validate_vault_config_missing_address() {
+        let _guard = env_lock().lock().unwrap();
+
         env::remove_var("VAULT_ADDR");
         env::remove_var("VAULT_TOKEN");
 
@@ -386,6 +396,8 @@ mod tests {
 
     #[test]
     fn test_validate_vault_config_with_env_vars() {
+        let _guard = env_lock().lock().unwrap();
+
         env::set_var("VAULT_ADDR", "http://localhost:8200");
         env::set_var("VAULT_TOKEN", "test-token");
 

--- a/docs/mvp/02-epics.md
+++ b/docs/mvp/02-epics.md
@@ -12,3 +12,5 @@
 |------|-------|---------|-------|
 | MVP-E5 | CI/Protections Simplification | MVP-grade protections documented and enforced without blocking velocity | PRs: #53, #64, #65 |
 | #121 | Contract & Schema Registry | Contract bundles publish via CI, versioned/signed, smoke-verified, fetched by tag, runtime ingestion, UI alerts/metrics | Stories: #124-#140; PRs: #132, #135-#137, #140 |
+
+> Note: Secrets env-lock fix folded into PR #203 to serialize env-mutating tests and unblock CI.


### PR DESCRIPTION
## Summary
- serialize the environment-mutating secrets tests behind a shared `OnceLock<Mutex<()>>`
- note in the MVP epics doc that the env-lock fix now lives in PR #203

## Testing
- `cargo fmt`
- `cargo test --workspace --all-features -- --nocapture`
- `scripts/contracts-validate.sh` *(fails: script not present in repository)*
- `scripts/check-doc-links.sh --quiet` *(fails: markdown-link-check not installed)*

------
https://chatgpt.com/codex/tasks/task_b_68db52084bac832ea20b1fb2d59956cf

Review-lock: ac47e179cd1f6ee13bf9c7678336b1bb9cc0ca5e