### PR TITLE
contracts: fix graph WIT import path

### DIFF
--- a/contracts/wit/demon-graph.wit
+++ b/contracts/wit/demon-graph.wit
@@ -4,7 +4,7 @@
 
 package demon:graph@0.1.0;
 
-use demon:contracts/demon-envelope.result-envelope;
+use demon:contracts/result-envelope;
 
 /// Identifies a graph scope within the Demon platform
 record scope {


### PR DESCRIPTION
## Summary
- adjust the demon graph WIT module to use the result-envelope import from the contracts package

## Testing
- cargo fmt
- scripts/contracts-validate.sh

------
https://chatgpt.com/codex/tasks/task_b_68db56bdc3f8832e8be57ddd186250d1

Review-lock: 20da65be040b166d4a93b605895cc73fd0d506ae