### PR TITLE
runtime: wire graph capsule + cli support (EPIC 4 follow-up)

### DIFF
--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -36,3 +36,4 @@ tempfile = "3.8"
 uuid = { workspace = true }
 reqwest = { version = "0.11", default-features = false, features = ["json", "rustls-tls"] }
 serial_test = "3.0"
+futures-util = { workspace = true }

--- a/runtime/tests/graph_dispatch_spec.rs
+++ b/runtime/tests/graph_dispatch_spec.rs
@@ -47,7 +47,7 @@ async fn given_graph_create_via_runtime_when_dispatched_then_commit_event_emitte
     // Assert - envelope is success
     let envelope_value = result;
     assert_eq!(envelope_value["result"]["success"].as_bool(), Some(true));
-    let commit_id = envelope_value["result"]["data"]["commitId"]
+    let commit_id = envelope_value["result"]["data"]["commit_id"]
         .as_str()
         .expect("Should have commit ID");
 
@@ -129,10 +129,10 @@ async fn given_graph_commit_via_runtime_when_dispatched_then_event_has_parent() 
     // Assert
     let envelope_value = result;
     assert_eq!(envelope_value["result"]["success"].as_bool(), Some(true));
-    let commit_id = envelope_value["result"]["data"]["commitId"]
+    let commit_id = envelope_value["result"]["data"]["commit_id"]
         .as_str()
         .expect("Should have commit ID");
-    let returned_parent = envelope_value["result"]["data"]["parentCommitId"]
+    let returned_parent = envelope_value["result"]["data"]["parent_commit_id"]
         .as_str()
         .expect("Should have parent commit ID");
     assert_eq!(returned_parent, parent_commit_id);
@@ -307,7 +307,7 @@ async fn given_get_node_via_runtime_when_dispatched_then_returns_node_snapshot()
     let create_result = router
         .dispatch("graph", &create_args, "test-run", "test-ritual")
         .await?;
-    let commit_id = create_result["result"]["data"]["commitId"]
+    let commit_id = create_result["result"]["data"]["commit_id"]
         .as_str()
         .expect("commit id present")
         .to_string();

--- a/runtime/tests/graph_dispatch_spec.rs
+++ b/runtime/tests/graph_dispatch_spec.rs
@@ -15,6 +15,7 @@ fn nats_url() -> String {
 }
 
 #[tokio::test]
+#[ignore]
 async fn given_graph_create_via_runtime_when_dispatched_then_commit_event_emitted() -> Result<()> {
     // Arrange
     let router = Router::new();
@@ -77,7 +78,7 @@ async fn given_graph_create_via_runtime_when_dispatched_then_commit_event_emitte
 
     let mut found_event = false;
     while let Some(msg) = batch.next().await {
-        let msg = msg?;
+        let msg = msg.map_err(|e| anyhow::anyhow!("Failed to get message: {}", e))?;
         let event: serde_json::Value = serde_json::from_slice(&msg.message.payload)?;
 
         if event["commitId"] == commit_id {
@@ -94,6 +95,7 @@ async fn given_graph_create_via_runtime_when_dispatched_then_commit_event_emitte
 }
 
 #[tokio::test]
+#[ignore]
 async fn given_graph_commit_via_runtime_when_dispatched_then_event_has_parent() -> Result<()> {
     // Arrange
     let router = Router::new();
@@ -162,7 +164,7 @@ async fn given_graph_commit_via_runtime_when_dispatched_then_event_has_parent() 
 
     let mut found_event = false;
     while let Some(msg) = batch.next().await {
-        let msg = msg?;
+        let msg = msg.map_err(|e| anyhow::anyhow!("Failed to get message: {}", e))?;
         let event: serde_json::Value = serde_json::from_slice(&msg.message.payload)?;
 
         if event["commitId"] == commit_id {
@@ -177,6 +179,7 @@ async fn given_graph_commit_via_runtime_when_dispatched_then_event_has_parent() 
 }
 
 #[tokio::test]
+#[ignore]
 async fn given_graph_tag_via_runtime_when_dispatched_then_tag_event_emitted() -> Result<()> {
     // Arrange
     let router = Router::new();
@@ -232,7 +235,7 @@ async fn given_graph_tag_via_runtime_when_dispatched_then_tag_event_emitted() ->
 
     let mut found_event = false;
     while let Some(msg) = batch.next().await {
-        let msg = msg?;
+        let msg = msg.map_err(|e| anyhow::anyhow!("Failed to get message: {}", e))?;
         let event: serde_json::Value = serde_json::from_slice(&msg.message.payload)?;
 
         if event["event"] == "graph.tag.updated:v1" && event["tag"] == tag {
@@ -248,6 +251,7 @@ async fn given_graph_tag_via_runtime_when_dispatched_then_tag_event_emitted() ->
 }
 
 #[tokio::test]
+#[ignore]
 async fn given_list_tags_via_runtime_when_dispatched_then_returns_placeholder() -> Result<()> {
     // Arrange
     let router = Router::new();
@@ -276,6 +280,7 @@ async fn given_list_tags_via_runtime_when_dispatched_then_returns_placeholder() 
 }
 
 #[tokio::test]
+#[ignore]
 async fn given_get_node_via_runtime_when_dispatched_then_returns_not_implemented() -> Result<()> {
     // Arrange
     let router = Router::new();

--- a/runtime/tests/graph_dispatch_spec.rs
+++ b/runtime/tests/graph_dispatch_spec.rs
@@ -46,7 +46,7 @@ async fn given_graph_create_via_runtime_when_dispatched_then_commit_event_emitte
 
     // Assert - envelope is success
     let envelope_value = result;
-    assert!(envelope_value["result"]["status"].as_str() == Some("success"));
+    assert_eq!(envelope_value["result"]["success"].as_bool(), Some(true));
     let commit_id = envelope_value["result"]["data"]["commitId"]
         .as_str()
         .expect("Should have commit ID");
@@ -128,7 +128,7 @@ async fn given_graph_commit_via_runtime_when_dispatched_then_event_has_parent() 
 
     // Assert
     let envelope_value = result;
-    assert!(envelope_value["result"]["status"].as_str() == Some("success"));
+    assert_eq!(envelope_value["result"]["success"].as_bool(), Some(true));
     let commit_id = envelope_value["result"]["data"]["commitId"]
         .as_str()
         .expect("Should have commit ID");
@@ -206,7 +206,7 @@ async fn given_graph_tag_via_runtime_when_dispatched_then_tag_event_emitted() ->
 
     // Assert
     let envelope_value = result;
-    assert!(envelope_value["result"]["status"].as_str() == Some("success"));
+    assert_eq!(envelope_value["result"]["success"].as_bool(), Some(true));
 
     // Verify tag event in JetStream
     let client = async_nats::connect(&nats_url()).await?;
@@ -273,7 +273,7 @@ async fn given_list_tags_via_runtime_when_dispatched_then_returns_placeholder() 
 
     // Assert - should succeed but return empty (placeholder)
     let envelope_value = result;
-    assert!(envelope_value["result"]["status"].as_str() == Some("success"));
+    assert_eq!(envelope_value["result"]["success"].as_bool(), Some(true));
     assert!(envelope_value["result"]["data"].is_array());
 
     Ok(())
@@ -304,7 +304,7 @@ async fn given_get_node_via_runtime_when_dispatched_then_returns_not_implemented
 
     // Assert - should return error with NOT_IMPLEMENTED
     let envelope_value = result;
-    assert!(envelope_value["result"]["status"].as_str() == Some("error"));
+    assert_eq!(envelope_value["result"]["success"].as_bool(), Some(false));
     assert!(envelope_value["result"]["error"]["code"] == "NOT_IMPLEMENTED");
 
     Ok(())


### PR DESCRIPTION
## Summary

Integrate graph capsule into runtime and demonctl, following up on PRs #217, #220 (graph commit/tag engine merged to main).

- **Runtime integration**: wire graph capsule into runtime router; support create/commit/tag/delete-tag/list-tags + query operations
- **CLI support**: add `demonctl graph` subcommands (create, commit, tag, list-tags, get-commit, get-tag)
- **Tests**: runtime integration tests verifying dispatch + JetStream event emission (all marked #[ignore], run in CI with --ignored)
- **Docs**: update ops guide and command cheat sheet with graph usage and REST API examples

## Changes

### Runtime (runtime/)
- **runtime/Cargo.toml**: add `capsules_graph` dependency; `futures-util` in dev-dependencies
- **runtime/src/link/router.rs**: wire graph operations including delete-tag (from main)
  - `dispatch_graph` helper routes create/commit/tag/delete-tag/list-tags/get-node/neighbors/path-exists
- **runtime/tests/graph_dispatch_spec.rs**: integration tests (all require NATS, marked #[ignore])
  - Verify dispatch for create, commit, tag operations
  - Verify JetStream events (GRAPH_COMMITS stream)
  - Tests run in CI with --ignored after NATS startup

### CLI (demonctl/)
- **demonctl/Cargo.toml**: add `capsules_graph` dependency
- **demonctl/src/main.rs**: Graph subcommand structure including GetCommit/GetTag REST API commands (from main)
  - Create, Commit, Tag, ListTags, GetCommit, GetTag operations
  - Scope args: --tenant-id, --project-id, --namespace, --graph-id
  - Mutations from JSON file
- `handle_graph_command`: outputs ResultEnvelope JSON; exits 1 on failure

### Documentation
- **docs/ops/README.md**: graph CLI examples + REST API curl examples + graph viewer in Operate UI
- **docs/quick-reference/command-cheat-sheet.md**: graph commands + REST API examples

## Test Plan

- [x] Rebased onto main (includes PRs #217, #220)
- [x] `cargo fmt && cargo clippy --workspace --all-features -- -D warnings` — clean
- [x] `cargo test --workspace --all-features` — passes (graph_dispatch_spec tests skipped with #[ignore])
- [x] `./scripts/contracts-validate.sh` — passes
- [x] `./scripts/check-doc-links.sh --quiet` — passes
- [x] CI will run ignored tests with `--ignored --nocapture` after NATS startup

## Contracts

- [x] No schema changes (graph schemas already exist from merged PRs)
- [x] No fixture updates needed

## Notes

- All tests in `runtime/tests/graph_dispatch_spec.rs` are marked `#[ignore]` because they require NATS JetStream
- CI workflow already has step to run these tests with `--ignored` (line 152-154 in .github/workflows/ci.yml)
- Addresses review thread discussion_r2390165818: tests are skip-by-default, run explicitly in CI

Fixes #207

EPIC 4: capsule(graph) - runtime dispatch & CLI


🤖 Generated with [Claude Code](https://claude.com/claude-code)
Review-lock: 18447e5d71684c2556bfc44d78bee1f3ae4cfca3