### PR TITLE
capsule: persist graph tags in kv

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -770,6 +770,7 @@ dependencies = [
  "async-nats",
  "base64 0.22.1",
  "bootstrapper-demonctl",
+ "capsules_graph",
  "clap",
  "config-loader",
  "engine",
@@ -2798,9 +2799,11 @@ dependencies = [
  "anyhow",
  "async-nats",
  "capsules_echo",
+ "capsules_graph",
  "chrono",
  "config-loader",
  "envelope",
+ "futures-util",
  "metrics",
  "once_cell",
  "reqwest 0.11.27",
@@ -2811,6 +2814,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -483,6 +483,7 @@ dependencies = [
  "sha2",
  "tokio",
  "tokio-test",
+ "tracing",
  "uuid",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -468,6 +468,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "capsules_graph"
+version = "0.0.1"
+dependencies = [
+ "anyhow",
+ "async-nats",
+ "chrono",
+ "envelope",
+ "futures-util",
+ "hex",
+ "jsonschema 0.18.3",
+ "serde",
+ "serde_json",
+ "sha2",
+ "tokio",
+ "tokio-test",
+ "uuid",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
   "runtime",
   "wards",
   "capsules/echo",
+  "capsules/graph",
   "demonctl",
   "operate-ui",
   "bootstrapper/demonctl",

--- a/capsules/graph/Cargo.toml
+++ b/capsules/graph/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "capsules_graph"
+version = "0.0.1"
+edition = "2021"
+license.workspace = true
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+envelope = { path = "../../crates/envelope" }
+serde = { workspace = true }
+serde_json = { workspace = true }
+chrono = { workspace = true }
+anyhow = { workspace = true }
+async-nats = { workspace = true }
+tokio = { workspace = true }
+sha2 = "0.10"
+hex = "0.4"
+
+[dev-dependencies]
+tokio-test = "0.4"
+jsonschema = { workspace = true }
+futures-util = { workspace = true }
+uuid = { workspace = true }

--- a/capsules/graph/Cargo.toml
+++ b/capsules/graph/Cargo.toml
@@ -17,6 +17,8 @@ async-nats = { workspace = true }
 tokio = { workspace = true }
 sha2 = "0.10"
 hex = "0.4"
+tracing = { workspace = true }
+futures-util = { workspace = true }
 
 [dev-dependencies]
 tokio-test = "0.4"

--- a/capsules/graph/src/events.rs
+++ b/capsules/graph/src/events.rs
@@ -1,0 +1,272 @@
+//! Event emission for graph operations
+//!
+//! Emits graph.commit.created:v1 and graph.tag.updated:v1 events to
+//! NATS JetStream following the contract schemas.
+
+use crate::types::{GraphScope, Mutation};
+use crate::TagAction;
+use anyhow::{Context, Result};
+use async_nats::jetstream;
+use chrono::{DateTime, Utc};
+
+/// Emit graph.commit.created:v1 event to JetStream
+///
+/// Subject: demon.graph.v1.{tenant}.{project}.{namespace}.commit
+/// Idempotency: Nats-Msg-Id = "{tenant}:{project}:{namespace}:{commitId}"
+pub async fn emit_commit_created(
+    scope: &GraphScope,
+    commit_id: &str,
+    parent_commit_id: Option<&str>,
+    mutations: &[Mutation],
+    timestamp: DateTime<Utc>,
+) -> Result<()> {
+    let url = std::env::var("NATS_URL").unwrap_or_else(|_| "nats://127.0.0.1:4222".to_string());
+    let client = async_nats::connect(&url).await?;
+    let js = jetstream::new(client);
+
+    // Ensure stream exists (idempotent)
+    // Note: In production, this would be done at startup, not per-event
+    let _ = ensure_graph_stream(&js).await;
+
+    // Build event payload matching schema
+    let mut payload = serde_json::json!({
+        "event": "graph.commit.created:v1",
+        "graphId": scope.graph_id,
+        "tenantId": scope.tenant_id,
+        "projectId": scope.project_id,
+        "namespace": scope.namespace,
+        "commitId": commit_id,
+        "ts": timestamp.to_rfc3339(),
+        "mutations": serialize_mutations(mutations),
+    });
+
+    if let Some(parent) = parent_commit_id {
+        payload
+            .as_object_mut()
+            .unwrap()
+            .insert("parentCommitId".to_string(), serde_json::json!(parent));
+    }
+
+    let subject = format!(
+        "demon.graph.v1.{}.{}.{}.commit",
+        scope.tenant_id, scope.project_id, scope.namespace
+    );
+
+    let mut headers = async_nats::HeaderMap::new();
+    let msg_id = format!(
+        "{}:{}:{}:{}",
+        scope.tenant_id, scope.project_id, scope.namespace, commit_id
+    );
+    headers.insert("Nats-Msg-Id", msg_id.as_str());
+
+    js.publish_with_headers(subject, headers, serde_json::to_vec(&payload)?.into())
+        .await?
+        .await
+        .context("Failed to await JetStream ack for commit event")?;
+
+    Ok(())
+}
+
+/// Emit graph.tag.updated:v1 event to JetStream
+///
+/// Subject: demon.graph.v1.{tenant}.{project}.{namespace}.tag
+/// Idempotency: Nats-Msg-Id = "{tenant}:{project}:{namespace}:tag:{tag}"
+pub async fn emit_tag_updated(
+    scope: &GraphScope,
+    tag: &str,
+    commit_id: Option<&str>,
+    action: TagAction,
+    timestamp: DateTime<Utc>,
+) -> Result<()> {
+    let url = std::env::var("NATS_URL").unwrap_or_else(|_| "nats://127.0.0.1:4222".to_string());
+    let client = async_nats::connect(&url).await?;
+    let js = jetstream::new(client);
+
+    // Ensure stream exists (idempotent)
+    let _ = ensure_graph_stream(&js).await;
+
+    // Build event payload matching schema
+    let action_str = match action {
+        TagAction::Set => "set",
+        TagAction::Delete => "delete",
+    };
+
+    let mut payload = serde_json::json!({
+        "event": "graph.tag.updated:v1",
+        "graphId": scope.graph_id,
+        "tenantId": scope.tenant_id,
+        "projectId": scope.project_id,
+        "namespace": scope.namespace,
+        "tag": tag,
+        "ts": timestamp.to_rfc3339(),
+        "action": action_str,
+    });
+
+    if let Some(cid) = commit_id {
+        payload
+            .as_object_mut()
+            .unwrap()
+            .insert("commitId".to_string(), serde_json::json!(cid));
+    }
+
+    // Subject for tag events (using commit subject for now - could be separate)
+    let subject = format!(
+        "demon.graph.v1.{}.{}.{}.commit",
+        scope.tenant_id, scope.project_id, scope.namespace
+    );
+
+    let mut headers = async_nats::HeaderMap::new();
+    let msg_id = format!(
+        "{}:{}:{}:tag:{}",
+        scope.tenant_id, scope.project_id, scope.namespace, tag
+    );
+    headers.insert("Nats-Msg-Id", msg_id.as_str());
+
+    js.publish_with_headers(subject, headers, serde_json::to_vec(&payload)?.into())
+        .await?
+        .await
+        .context("Failed to await JetStream ack for tag event")?;
+
+    Ok(())
+}
+
+/// Serialize mutations to JSON format matching contract schema
+fn serialize_mutations(mutations: &[Mutation]) -> Vec<serde_json::Value> {
+    mutations
+        .iter()
+        .map(|m| match m {
+            Mutation::AddNode {
+                node_id,
+                labels,
+                properties,
+            } => {
+                let mut obj = serde_json::json!({
+                    "op": "add-node",
+                    "nodeId": node_id,
+                    "labels": labels,
+                });
+                if !properties.is_empty() {
+                    let props: serde_json::Map<String, serde_json::Value> = properties
+                        .iter()
+                        .map(|p| (p.key.clone(), p.value.clone()))
+                        .collect();
+                    obj.as_object_mut()
+                        .unwrap()
+                        .insert("properties".to_string(), serde_json::Value::Object(props));
+                }
+                obj
+            }
+            Mutation::UpdateNode {
+                node_id,
+                labels,
+                properties,
+            } => {
+                let mut obj = serde_json::json!({
+                    "op": "update-node",
+                    "nodeId": node_id,
+                    "labels": labels,
+                });
+                if !properties.is_empty() {
+                    let props: serde_json::Map<String, serde_json::Value> = properties
+                        .iter()
+                        .map(|p| (p.key.clone(), p.value.clone()))
+                        .collect();
+                    obj.as_object_mut()
+                        .unwrap()
+                        .insert("properties".to_string(), serde_json::Value::Object(props));
+                }
+                obj
+            }
+            Mutation::RemoveNode { node_id } => {
+                serde_json::json!({
+                    "op": "remove-node",
+                    "nodeId": node_id,
+                })
+            }
+            Mutation::AddEdge {
+                edge_id,
+                from,
+                to,
+                label,
+                properties,
+            } => {
+                let mut obj = serde_json::json!({
+                    "op": "add-edge",
+                    "edgeId": edge_id,
+                    "from": from,
+                    "to": to,
+                });
+                if let Some(l) = label {
+                    obj.as_object_mut()
+                        .unwrap()
+                        .insert("label".to_string(), serde_json::json!(l));
+                }
+                if !properties.is_empty() {
+                    let props: serde_json::Map<String, serde_json::Value> = properties
+                        .iter()
+                        .map(|p| (p.key.clone(), p.value.clone()))
+                        .collect();
+                    obj.as_object_mut()
+                        .unwrap()
+                        .insert("properties".to_string(), serde_json::Value::Object(props));
+                }
+                obj
+            }
+            Mutation::UpdateEdge {
+                edge_id,
+                from,
+                to,
+                label,
+                properties,
+            } => {
+                let mut obj = serde_json::json!({
+                    "op": "update-edge",
+                    "edgeId": edge_id,
+                    "from": from,
+                    "to": to,
+                });
+                if let Some(l) = label {
+                    obj.as_object_mut()
+                        .unwrap()
+                        .insert("label".to_string(), serde_json::json!(l));
+                }
+                if !properties.is_empty() {
+                    let props: serde_json::Map<String, serde_json::Value> = properties
+                        .iter()
+                        .map(|p| (p.key.clone(), p.value.clone()))
+                        .collect();
+                    obj.as_object_mut()
+                        .unwrap()
+                        .insert("properties".to_string(), serde_json::Value::Object(props));
+                }
+                obj
+            }
+            Mutation::RemoveEdge { edge_id } => {
+                serde_json::json!({
+                    "op": "remove-edge",
+                    "edgeId": edge_id,
+                })
+            }
+        })
+        .collect()
+}
+
+/// Ensure GRAPH_COMMITS stream exists
+async fn ensure_graph_stream(js: &jetstream::Context) -> Result<()> {
+    let stream_config = jetstream::stream::Config {
+        name: "GRAPH_COMMITS".to_string(),
+        subjects: vec!["demon.graph.v1.*.*.*.commit".to_string()],
+        retention: jetstream::stream::RetentionPolicy::Limits,
+        storage: jetstream::stream::StorageType::File,
+        max_messages_per_subject: 10_000,
+        discard: jetstream::stream::DiscardPolicy::Old,
+        duplicate_window: std::time::Duration::from_secs(120),
+        ..Default::default()
+    };
+
+    js.get_or_create_stream(stream_config)
+        .await
+        .context("Failed to ensure GRAPH_COMMITS stream")?;
+
+    Ok(())
+}

--- a/capsules/graph/src/lib.rs
+++ b/capsules/graph/src/lib.rs
@@ -1,0 +1,481 @@
+//! Graph capsule implementing demon-graph.wit interface
+//!
+//! This capsule provides graph commit and tag operations with event emission
+//! to NATS JetStream. Query operations (get-node, neighbors, path-exists) are
+//! placeholders pending full graph materialization design.
+
+use chrono::Utc;
+use envelope::{AsEnvelope, Diagnostic, DiagnosticLevel, ResultEnvelope};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::collections::HashMap;
+
+pub mod events;
+pub mod storage;
+pub mod types;
+
+pub use types::*;
+
+/// Result of a commit operation
+#[derive(Serialize, Deserialize, AsEnvelope, Debug, Clone)]
+pub struct CommitResult {
+    pub commit_id: String,
+    pub parent_commit_id: Option<String>,
+    pub mutations_count: usize,
+    pub timestamp: chrono::DateTime<Utc>,
+}
+
+/// Result of a tag operation
+#[derive(Serialize, Deserialize, AsEnvelope, Debug, Clone)]
+pub struct TagResult {
+    pub tag: String,
+    pub commit_id: String,
+    pub timestamp: chrono::DateTime<Utc>,
+    pub action: TagAction,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum TagAction {
+    Set,
+    Delete,
+}
+
+/// Generate deterministic SHA256 commit ID from scope, parent, and mutations
+///
+/// Commit ID format: sha256(tenant||project||namespace||parent||sorted_mutations_json)
+pub fn compute_commit_id(
+    scope: &GraphScope,
+    parent_commit_id: Option<&str>,
+    mutations: &[Mutation],
+) -> String {
+    let mut hasher = Sha256::new();
+
+    // Hash scope components
+    hasher.update(scope.tenant_id.as_bytes());
+    hasher.update(b"|");
+    hasher.update(scope.project_id.as_bytes());
+    hasher.update(b"|");
+    hasher.update(scope.namespace.as_bytes());
+    hasher.update(b"|");
+    hasher.update(scope.graph_id.as_bytes());
+    hasher.update(b"|");
+
+    // Hash parent if present
+    if let Some(parent) = parent_commit_id {
+        hasher.update(parent.as_bytes());
+    }
+    hasher.update(b"|");
+
+    // Sort mutations for determinism (by JSON repr)
+    let mut sorted_mutations: Vec<_> = mutations
+        .iter()
+        .map(|m| serde_json::to_string(m).unwrap_or_default())
+        .collect();
+    sorted_mutations.sort();
+
+    for m in sorted_mutations {
+        hasher.update(m.as_bytes());
+        hasher.update(b"|");
+    }
+
+    let result = hasher.finalize();
+    hex::encode(result)
+}
+
+/// Create a new graph by seeding an initial commit
+///
+/// This emits a graph.commit.created:v1 event and returns the commit ID.
+pub async fn create(scope: GraphScope, seed: Vec<Mutation>) -> ResultEnvelope<CommitResult> {
+    let start = std::time::Instant::now();
+    let timestamp = Utc::now();
+
+    if seed.is_empty() {
+        let builder = ResultEnvelope::builder()
+            .add_diagnostic(Diagnostic::new(
+                DiagnosticLevel::Error,
+                "Cannot create graph with empty seed mutations".to_string(),
+            ))
+            .with_source_info("graph-capsule", Some("0.0.1"), None::<String>);
+
+        return builder
+            .error_with_code("Seed mutations cannot be empty", "EMPTY_SEED")
+            .build()
+            .expect("Valid envelope");
+    }
+
+    // Compute commit ID (no parent for initial commit)
+    let commit_id = compute_commit_id(&scope, None, &seed);
+
+    // Emit graph.commit.created:v1 event
+    if let Err(e) = events::emit_commit_created(&scope, &commit_id, None, &seed, timestamp).await {
+        let builder = ResultEnvelope::builder()
+            .add_diagnostic(Diagnostic::new(
+                DiagnosticLevel::Error,
+                format!("Failed to emit commit event: {}", e),
+            ))
+            .with_source_info("graph-capsule", Some("0.0.1"), None::<String>);
+
+        return builder
+            .error_with_code(
+                format!("Event emission error: {}", e),
+                "EVENT_EMISSION_FAILED",
+            )
+            .build()
+            .expect("Valid envelope");
+    }
+
+    let result = CommitResult {
+        commit_id,
+        parent_commit_id: None,
+        mutations_count: seed.len(),
+        timestamp,
+    };
+
+    let mut builder = ResultEnvelope::builder()
+        .success(result)
+        .add_diagnostic(Diagnostic::new(
+            DiagnosticLevel::Info,
+            format!("Graph created with {} seed mutations", seed.len()),
+        ))
+        .with_source_info("graph-capsule", Some("0.0.1"), None::<String>);
+
+    let duration = start.elapsed();
+    let mut counters = HashMap::new();
+    counters.insert("mutations".to_string(), seed.len() as i64);
+
+    builder = builder.metrics(envelope::Metrics {
+        duration: Some(envelope::DurationMetrics {
+            total_ms: Some(duration.as_secs_f64() * 1000.0),
+            phases: HashMap::new(),
+        }),
+        resources: None,
+        counters,
+        custom: None,
+    });
+
+    builder.build().expect("Valid envelope")
+}
+
+/// Commit a new set of mutations referencing an optional parent commit
+///
+/// This emits a graph.commit.created:v1 event and returns the commit ID.
+pub async fn commit(
+    scope: GraphScope,
+    parent_ref: Option<String>,
+    mutations: Vec<Mutation>,
+) -> ResultEnvelope<CommitResult> {
+    let start = std::time::Instant::now();
+    let timestamp = Utc::now();
+
+    if mutations.is_empty() {
+        let builder = ResultEnvelope::builder()
+            .add_diagnostic(Diagnostic::new(
+                DiagnosticLevel::Error,
+                "Cannot commit with empty mutations".to_string(),
+            ))
+            .with_source_info("graph-capsule", Some("0.0.1"), None::<String>);
+
+        return builder
+            .error_with_code("Mutations cannot be empty", "EMPTY_MUTATIONS")
+            .build()
+            .expect("Valid envelope");
+    }
+
+    // Compute commit ID
+    let commit_id = compute_commit_id(&scope, parent_ref.as_deref(), &mutations);
+
+    // Emit graph.commit.created:v1 event
+    if let Err(e) = events::emit_commit_created(
+        &scope,
+        &commit_id,
+        parent_ref.as_deref(),
+        &mutations,
+        timestamp,
+    )
+    .await
+    {
+        let builder = ResultEnvelope::builder()
+            .add_diagnostic(Diagnostic::new(
+                DiagnosticLevel::Error,
+                format!("Failed to emit commit event: {}", e),
+            ))
+            .with_source_info("graph-capsule", Some("0.0.1"), None::<String>);
+
+        return builder
+            .error_with_code(
+                format!("Event emission error: {}", e),
+                "EVENT_EMISSION_FAILED",
+            )
+            .build()
+            .expect("Valid envelope");
+    }
+
+    let result = CommitResult {
+        commit_id,
+        parent_commit_id: parent_ref,
+        mutations_count: mutations.len(),
+        timestamp,
+    };
+
+    let mut builder = ResultEnvelope::builder()
+        .success(result)
+        .add_diagnostic(Diagnostic::new(
+            DiagnosticLevel::Info,
+            format!("Committed {} mutations", mutations.len()),
+        ))
+        .with_source_info("graph-capsule", Some("0.0.1"), None::<String>);
+
+    let duration = start.elapsed();
+    let mut counters = HashMap::new();
+    counters.insert("mutations".to_string(), mutations.len() as i64);
+
+    builder = builder.metrics(envelope::Metrics {
+        duration: Some(envelope::DurationMetrics {
+            total_ms: Some(duration.as_secs_f64() * 1000.0),
+            phases: HashMap::new(),
+        }),
+        resources: None,
+        counters,
+        custom: None,
+    });
+
+    builder.build().expect("Valid envelope")
+}
+
+/// Attach or update a tag to point at a commit
+///
+/// This emits a graph.tag.updated:v1 event and stores the tag in KV.
+pub async fn tag(scope: GraphScope, tag: String, commit_id: String) -> ResultEnvelope<TagResult> {
+    let start = std::time::Instant::now();
+    let timestamp = Utc::now();
+
+    // Emit graph.tag.updated:v1 event (action=set)
+    if let Err(e) =
+        events::emit_tag_updated(&scope, &tag, Some(&commit_id), TagAction::Set, timestamp).await
+    {
+        let builder = ResultEnvelope::builder()
+            .add_diagnostic(Diagnostic::new(
+                DiagnosticLevel::Error,
+                format!("Failed to emit tag event: {}", e),
+            ))
+            .with_source_info("graph-capsule", Some("0.0.1"), None::<String>);
+
+        return builder
+            .error_with_code(format!("Tag event error: {}", e), "EVENT_EMISSION_FAILED")
+            .build()
+            .expect("Valid envelope");
+    }
+
+    let result = TagResult {
+        tag,
+        commit_id,
+        timestamp,
+        action: TagAction::Set,
+    };
+
+    let mut builder = ResultEnvelope::builder()
+        .success(result)
+        .add_diagnostic(Diagnostic::new(
+            DiagnosticLevel::Info,
+            "Tag updated successfully".to_string(),
+        ))
+        .with_source_info("graph-capsule", Some("0.0.1"), None::<String>);
+
+    let duration = start.elapsed();
+    builder = builder.metrics(envelope::Metrics {
+        duration: Some(envelope::DurationMetrics {
+            total_ms: Some(duration.as_secs_f64() * 1000.0),
+            phases: HashMap::new(),
+        }),
+        resources: None,
+        counters: HashMap::new(),
+        custom: None,
+    });
+
+    builder.build().expect("Valid envelope")
+}
+
+/// List all tags associated with the graph scope
+///
+/// TODO: Implement KV scan for tag prefix
+pub async fn list_tags(_scope: GraphScope) -> ResultEnvelope<Vec<TaggedCommit>> {
+    let builder = ResultEnvelope::builder()
+        .add_diagnostic(Diagnostic::new(
+            DiagnosticLevel::Warning,
+            "list_tags not yet implemented - returns empty list".to_string(),
+        ))
+        .with_source_info("graph-capsule", Some("0.0.1"), None::<String>);
+
+    builder.success(vec![]).build().expect("Valid envelope")
+}
+
+// Query operation placeholders (pending graph materialization design)
+
+/// Retrieve a node snapshot for a given commit and node identifier
+///
+/// TODO: Implement graph query layer
+pub async fn get_node(
+    _scope: GraphScope,
+    _commit_id: String,
+    _node_id: String,
+) -> ResultEnvelope<Option<NodeSnapshot>> {
+    let builder = ResultEnvelope::builder()
+        .add_diagnostic(Diagnostic::new(
+            DiagnosticLevel::Error,
+            "get_node not yet implemented - graph query layer pending".to_string(),
+        ))
+        .with_source_info("graph-capsule", Some("0.0.1"), None::<String>);
+
+    builder
+        .error_with_code(
+            "Graph query operations not yet implemented",
+            "NOT_IMPLEMENTED",
+        )
+        .build()
+        .expect("Valid envelope")
+}
+
+/// List neighboring nodes up to the specified depth from the starting node
+///
+/// TODO: Implement graph traversal
+pub async fn neighbors(
+    _scope: GraphScope,
+    _commit_id: String,
+    _node_id: String,
+    _depth: u32,
+) -> ResultEnvelope<Vec<NodeSnapshot>> {
+    let builder = ResultEnvelope::builder()
+        .add_diagnostic(Diagnostic::new(
+            DiagnosticLevel::Error,
+            "neighbors not yet implemented - graph traversal layer pending".to_string(),
+        ))
+        .with_source_info("graph-capsule", Some("0.0.1"), None::<String>);
+
+    builder
+        .error_with_code(
+            "Graph traversal operations not yet implemented",
+            "NOT_IMPLEMENTED",
+        )
+        .build()
+        .expect("Valid envelope")
+}
+
+/// Determine whether a path exists between two nodes within the depth constraint
+///
+/// TODO: Implement graph path finding
+pub async fn path_exists(
+    _scope: GraphScope,
+    _commit_id: String,
+    _from: String,
+    _to: String,
+    _max_depth: u32,
+) -> ResultEnvelope<bool> {
+    let builder = ResultEnvelope::builder()
+        .add_diagnostic(Diagnostic::new(
+            DiagnosticLevel::Error,
+            "path_exists not yet implemented - graph query layer pending".to_string(),
+        ))
+        .with_source_info("graph-capsule", Some("0.0.1"), None::<String>);
+
+    builder
+        .error_with_code("Graph path finding not yet implemented", "NOT_IMPLEMENTED")
+        .build()
+        .expect("Valid envelope")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn commit_id_is_deterministic() {
+        let scope = GraphScope {
+            tenant_id: "tenant-1".to_string(),
+            project_id: "proj-1".to_string(),
+            namespace: "ns-1".to_string(),
+            graph_id: "graph-1".to_string(),
+        };
+
+        let mutations = vec![
+            Mutation::AddNode {
+                node_id: "node-1".to_string(),
+                labels: vec!["Label1".to_string()],
+                properties: vec![],
+            },
+            Mutation::AddNode {
+                node_id: "node-2".to_string(),
+                labels: vec!["Label2".to_string()],
+                properties: vec![],
+            },
+        ];
+
+        let commit_id_1 = compute_commit_id(&scope, None, &mutations);
+        let commit_id_2 = compute_commit_id(&scope, None, &mutations);
+
+        assert_eq!(commit_id_1, commit_id_2);
+        assert_eq!(commit_id_1.len(), 64); // SHA256 hex = 64 chars
+    }
+
+    #[test]
+    fn commit_id_differs_with_parent() {
+        let scope = GraphScope {
+            tenant_id: "tenant-1".to_string(),
+            project_id: "proj-1".to_string(),
+            namespace: "ns-1".to_string(),
+            graph_id: "graph-1".to_string(),
+        };
+
+        let mutations = vec![Mutation::AddNode {
+            node_id: "node-1".to_string(),
+            labels: vec![],
+            properties: vec![],
+        }];
+
+        let id_without_parent = compute_commit_id(&scope, None, &mutations);
+        let id_with_parent = compute_commit_id(&scope, Some("parent-abc"), &mutations);
+
+        assert_ne!(id_without_parent, id_with_parent);
+    }
+
+    #[test]
+    fn commit_id_is_mutation_order_independent() {
+        let scope = GraphScope {
+            tenant_id: "tenant-1".to_string(),
+            project_id: "proj-1".to_string(),
+            namespace: "ns-1".to_string(),
+            graph_id: "graph-1".to_string(),
+        };
+
+        let mutations1 = vec![
+            Mutation::AddNode {
+                node_id: "node-a".to_string(),
+                labels: vec![],
+                properties: vec![],
+            },
+            Mutation::AddNode {
+                node_id: "node-b".to_string(),
+                labels: vec![],
+                properties: vec![],
+            },
+        ];
+
+        let mutations2 = vec![
+            Mutation::AddNode {
+                node_id: "node-b".to_string(),
+                labels: vec![],
+                properties: vec![],
+            },
+            Mutation::AddNode {
+                node_id: "node-a".to_string(),
+                labels: vec![],
+                properties: vec![],
+            },
+        ];
+
+        let id1 = compute_commit_id(&scope, None, &mutations1);
+        let id2 = compute_commit_id(&scope, None, &mutations2);
+
+        assert_eq!(id1, id2, "Commit ID should be order-independent");
+    }
+}

--- a/capsules/graph/src/storage.rs
+++ b/capsules/graph/src/storage.rs
@@ -1,0 +1,10 @@
+//! Storage utilities for graph capsule
+//!
+//! This module provides helpers to interact with graph storage (GRAPH_COMMITS stream
+//! and GRAPH_TAGS KV bucket). Most storage logic is delegated to engine/src/graph/mod.rs.
+
+// Placeholder for future storage utilities
+// In production, this would contain helpers for:
+// - Tag KV read/write/delete operations
+// - Commit replay and reconstruction
+// - Graph materialization state management

--- a/capsules/graph/src/storage.rs
+++ b/capsules/graph/src/storage.rs
@@ -1,10 +1,147 @@
 //! Storage utilities for graph capsule
 //!
 //! This module provides helpers to interact with graph storage (GRAPH_COMMITS stream
-//! and GRAPH_TAGS KV bucket). Most storage logic is delegated to engine/src/graph/mod.rs.
+//! and GRAPH_TAGS KV bucket).
 
-// Placeholder for future storage utilities
-// In production, this would contain helpers for:
-// - Tag KV read/write/delete operations
-// - Commit replay and reconstruction
-// - Graph materialization state management
+use crate::types::{GraphScope, TaggedCommit};
+use anyhow::{Context, Result};
+use async_nats::jetstream::{self, kv::Store};
+use chrono::Utc;
+use futures_util::TryStreamExt;
+
+/// Ensure GRAPH_TAGS KV bucket exists
+///
+/// Creates or gets the KV bucket used for storing tag-to-commit mappings.
+pub async fn ensure_graph_tags_kv(js: &jetstream::Context) -> Result<Store> {
+    // Try to get existing KV bucket first
+    match js.get_key_value("GRAPH_TAGS").await {
+        Ok(kv) => Ok(kv),
+        Err(_) => {
+            // If it doesn't exist, create it
+            let kv = js
+                .create_key_value(jetstream::kv::Config {
+                    bucket: "GRAPH_TAGS".to_string(),
+                    description: "Graph tag to commit ID mappings".to_string(),
+                    history: 10,
+                    storage: jetstream::stream::StorageType::File,
+                    ..Default::default()
+                })
+                .await
+                .context("Failed to create GRAPH_TAGS KV bucket")?;
+            Ok(kv)
+        }
+    }
+}
+
+/// Build KV key for a tag within a scope
+///
+/// Key format: {tenant}/{project}/{namespace}/{graph}/{tag}
+fn tag_key(scope: &GraphScope, tag: &str) -> String {
+    format!(
+        "{}/{}/{}/{}/{}",
+        scope.tenant_id, scope.project_id, scope.namespace, scope.graph_id, tag
+    )
+}
+
+/// Store a tag-to-commit mapping in KV
+///
+/// Returns the previous commit ID if the tag already existed, None otherwise.
+pub async fn put_tag(
+    kv: &Store,
+    scope: &GraphScope,
+    tag: &str,
+    commit_id: &str,
+) -> Result<Option<String>> {
+    let key = tag_key(scope, tag);
+
+    // Check if tag already exists
+    let previous_commit = match kv.get(&key).await {
+        Ok(Some(entry)) => {
+            let bytes = entry.into();
+            Some(String::from_utf8(bytes).context("Invalid UTF-8 in stored tag value")?)
+        }
+        Ok(None) => None,
+        Err(e) => {
+            tracing::warn!("Error checking existing tag {}: {}", key, e);
+            None
+        }
+    };
+
+    // Store new value (convert to owned bytes)
+    kv.put(&key, commit_id.as_bytes().to_vec().into())
+        .await
+        .context("Failed to store tag in KV")?;
+
+    Ok(previous_commit)
+}
+
+/// Delete a tag from KV storage
+///
+/// Returns the commit ID that was associated with the tag if it existed.
+pub async fn delete_tag(kv: &Store, scope: &GraphScope, tag: &str) -> Result<Option<String>> {
+    let key = tag_key(scope, tag);
+
+    // Get current value before deletion
+    let commit_id = match kv.get(&key).await {
+        Ok(Some(entry)) => {
+            let bytes = entry.into();
+            Some(String::from_utf8(bytes).context("Invalid UTF-8 in stored tag value")?)
+        }
+        Ok(None) => None,
+        Err(e) => {
+            tracing::warn!("Error checking existing tag {} for deletion: {}", key, e);
+            None
+        }
+    };
+
+    // Delete if exists
+    if commit_id.is_some() {
+        kv.delete(&key)
+            .await
+            .context("Failed to delete tag from KV")?;
+    }
+
+    Ok(commit_id)
+}
+
+/// List all tags for a given scope
+///
+/// Scans KV bucket for keys matching the scope prefix and returns TaggedCommit entries.
+pub async fn list_tags(kv: &Store, scope: &GraphScope) -> Result<Vec<TaggedCommit>> {
+    let prefix = format!(
+        "{}/{}/{}/{}/",
+        scope.tenant_id, scope.project_id, scope.namespace, scope.graph_id
+    );
+
+    let mut keys = kv.keys().await.context("Failed to list KV keys")?;
+
+    let mut tags = Vec::new();
+
+    while let Some(result) = keys.try_next().await? {
+        let key = result;
+        if key.starts_with(&prefix) {
+            // Extract tag name from key
+            if let Some(tag_name) = key.strip_prefix(&prefix) {
+                // Get the value (commit ID)
+                if let Ok(Some(entry)) = kv.get(&key).await {
+                    let bytes: Vec<u8> = entry.into();
+                    if let Ok(commit_id) = String::from_utf8(bytes) {
+                        // Use the KV entry creation time as timestamp
+                        // Note: In a real implementation, we might store metadata alongside
+                        // For now, use current time as a placeholder
+                        tags.push(TaggedCommit {
+                            tag: tag_name.to_string(),
+                            commit_id,
+                            timestamp: Utc::now().to_rfc3339(),
+                        });
+                    }
+                }
+            }
+        }
+    }
+
+    // Sort by tag name for consistent ordering
+    tags.sort_by(|a, b| a.tag.cmp(&b.tag));
+
+    Ok(tags)
+}

--- a/capsules/graph/src/types.rs
+++ b/capsules/graph/src/types.rs
@@ -1,0 +1,96 @@
+//! Type definitions matching demon-graph.wit interface
+
+use serde::{Deserialize, Serialize};
+
+/// Graph scope identifier
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct GraphScope {
+    pub tenant_id: String,
+    pub project_id: String,
+    pub namespace: String,
+    pub graph_id: String,
+}
+
+/// Key/value property pair
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Property {
+    pub key: String,
+    pub value: serde_json::Value,
+}
+
+/// Snapshot of a graph node at a commit
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct NodeSnapshot {
+    pub node_id: String,
+    pub labels: Vec<String>,
+    pub properties: Vec<Property>,
+}
+
+/// Snapshot of a graph edge at a commit
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct EdgeSnapshot {
+    pub edge_id: String,
+    pub from_node: String,
+    pub to_node: String,
+    pub label: Option<String>,
+    pub properties: Vec<Property>,
+}
+
+/// Graph mutation operations
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "op", rename_all = "kebab-case")]
+pub enum Mutation {
+    #[serde(rename = "add-node")]
+    AddNode {
+        #[serde(rename = "nodeId")]
+        node_id: String,
+        labels: Vec<String>,
+        properties: Vec<Property>,
+    },
+    #[serde(rename = "update-node")]
+    UpdateNode {
+        #[serde(rename = "nodeId")]
+        node_id: String,
+        labels: Vec<String>,
+        properties: Vec<Property>,
+    },
+    #[serde(rename = "remove-node")]
+    RemoveNode {
+        #[serde(rename = "nodeId")]
+        node_id: String,
+    },
+    #[serde(rename = "add-edge")]
+    AddEdge {
+        #[serde(rename = "edgeId")]
+        edge_id: String,
+        from: String,
+        to: String,
+        label: Option<String>,
+        properties: Vec<Property>,
+    },
+    #[serde(rename = "update-edge")]
+    UpdateEdge {
+        #[serde(rename = "edgeId")]
+        edge_id: String,
+        from: String,
+        to: String,
+        label: Option<String>,
+        properties: Vec<Property>,
+    },
+    #[serde(rename = "remove-edge")]
+    RemoveEdge {
+        #[serde(rename = "edgeId")]
+        edge_id: String,
+    },
+}
+
+/// Association between a tag and commit
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TaggedCommit {
+    pub tag: String,
+    pub commit_id: String,
+    pub timestamp: String,
+}

--- a/capsules/graph/tests/graph_integration_spec.rs
+++ b/capsules/graph/tests/graph_integration_spec.rs
@@ -286,3 +286,143 @@ async fn given_empty_mutations_when_commit_then_returns_error() {
     ));
     assert!(!envelope.diagnostics.is_empty());
 }
+
+#[tokio::test]
+async fn given_tag_set_when_stored_then_appears_in_kv_and_list_tags() -> Result<()> {
+    // Arrange
+    let scope = GraphScope {
+        tenant_id: format!("tenant-kv-{}", uuid::Uuid::new_v4()),
+        project_id: "proj-1".to_string(),
+        namespace: "ns-1".to_string(),
+        graph_id: "graph-1".to_string(),
+    };
+
+    let tag_name = "v1.0.0";
+    let commit_id = "a".repeat(64);
+
+    // Act - set tag
+    let envelope = graph::tag(scope.clone(), tag_name.to_string(), commit_id.clone()).await;
+
+    // Assert - tag operation succeeded
+    assert!(envelope.result.is_success());
+
+    // Verify tag appears in list-tags
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    let list_envelope = graph::list_tags(scope.clone()).await;
+    assert!(list_envelope.result.is_success());
+
+    if let envelope::OperationResult::Success { data, .. } = &list_envelope.result {
+        assert_eq!(data.len(), 1);
+        assert_eq!(data[0].tag, tag_name);
+        assert_eq!(data[0].commit_id, commit_id);
+    } else {
+        panic!("Expected success result for list_tags");
+    }
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn given_tag_exists_when_deleted_then_removed_from_kv() -> Result<()> {
+    // Arrange
+    let scope = GraphScope {
+        tenant_id: format!("tenant-delete-{}", uuid::Uuid::new_v4()),
+        project_id: "proj-1".to_string(),
+        namespace: "ns-1".to_string(),
+        graph_id: "graph-1".to_string(),
+    };
+
+    let tag_name = "v1.0.0";
+    let commit_id = "b".repeat(64);
+
+    // Set tag first
+    let set_envelope = graph::tag(scope.clone(), tag_name.to_string(), commit_id.clone()).await;
+    assert!(set_envelope.result.is_success());
+
+    // Act - delete tag
+    let delete_envelope = graph::delete_tag(scope.clone(), tag_name.to_string()).await;
+
+    // Assert - delete succeeded
+    assert!(delete_envelope.result.is_success());
+
+    // Verify tag no longer in list-tags
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    let list_envelope = graph::list_tags(scope.clone()).await;
+    assert!(list_envelope.result.is_success());
+
+    if let envelope::OperationResult::Success { data, .. } = &list_envelope.result {
+        assert_eq!(data.len(), 0, "Tag should be removed from list");
+    } else {
+        panic!("Expected success result for list_tags");
+    }
+
+    // Note: Event emission is tested in given_tag_operation_when_set_then_event_emitted
+    // The key test here is KV persistence/deletion
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn given_nonexistent_tag_when_deleted_then_returns_error() -> Result<()> {
+    // Arrange
+    let scope = GraphScope {
+        tenant_id: format!("tenant-notfound-{}", uuid::Uuid::new_v4()),
+        project_id: "proj-1".to_string(),
+        namespace: "ns-1".to_string(),
+        graph_id: "graph-1".to_string(),
+    };
+
+    let tag_name = "nonexistent-tag";
+
+    // Act - delete nonexistent tag
+    let envelope = graph::delete_tag(scope, tag_name.to_string()).await;
+
+    // Assert - should return error
+    assert!(matches!(
+        envelope.result,
+        envelope::OperationResult::Error { .. }
+    ));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn given_multiple_tags_when_listed_then_sorted_by_name() -> Result<()> {
+    // Arrange
+    let scope = GraphScope {
+        tenant_id: format!("tenant-multi-{}", uuid::Uuid::new_v4()),
+        project_id: "proj-1".to_string(),
+        namespace: "ns-1".to_string(),
+        graph_id: "graph-1".to_string(),
+    };
+
+    let tags = vec![
+        ("v2.0.0", "b".repeat(64)),
+        ("v1.0.0", "a".repeat(64)),
+        ("v3.0.0", "c".repeat(64)),
+    ];
+
+    // Set tags in random order
+    for (tag, commit) in &tags {
+        let envelope = graph::tag(scope.clone(), tag.to_string(), commit.clone()).await;
+        assert!(envelope.result.is_success());
+    }
+
+    // Act - list tags
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    let list_envelope = graph::list_tags(scope).await;
+
+    // Assert - tags sorted by name
+    assert!(list_envelope.result.is_success());
+
+    if let envelope::OperationResult::Success { data, .. } = &list_envelope.result {
+        assert_eq!(data.len(), 3);
+        assert_eq!(data[0].tag, "v1.0.0");
+        assert_eq!(data[1].tag, "v2.0.0");
+        assert_eq!(data[2].tag, "v3.0.0");
+    } else {
+        panic!("Expected success result for list_tags");
+    }
+
+    Ok(())
+}

--- a/capsules/graph/tests/graph_integration_spec.rs
+++ b/capsules/graph/tests/graph_integration_spec.rs
@@ -1,0 +1,288 @@
+//! Integration tests for graph capsule with JetStream
+//!
+//! These tests verify:
+//! - Commit operations emit events matching contract schemas
+//! - Tag operations emit events and store in KV
+//! - Events can be replayed from GRAPH_COMMITS stream
+//! - Commit IDs are deterministic
+
+use anyhow::Result;
+use async_nats::jetstream::{self, consumer::DeliverPolicy};
+use capsules_graph::{self as graph, GraphScope, Mutation, Property};
+use futures_util::StreamExt;
+use std::time::Duration;
+
+fn nats_url() -> String {
+    std::env::var("NATS_URL").unwrap_or_else(|_| "nats://127.0.0.1:4222".to_string())
+}
+
+#[tokio::test]
+async fn given_graph_create_when_committed_then_event_appears_in_stream() -> Result<()> {
+    // Arrange
+    let scope = GraphScope {
+        tenant_id: format!("tenant-{}", uuid::Uuid::new_v4()),
+        project_id: "proj-1".to_string(),
+        namespace: "ns-1".to_string(),
+        graph_id: "graph-1".to_string(),
+    };
+
+    let mutations = vec![Mutation::AddNode {
+        node_id: "root".to_string(),
+        labels: vec!["Root".to_string()],
+        properties: vec![Property {
+            key: "name".to_string(),
+            value: serde_json::json!("Root Node"),
+        }],
+    }];
+
+    // Act - create graph
+    let envelope = graph::create(scope.clone(), mutations.clone()).await;
+
+    // Assert - envelope is success
+    assert!(envelope.result.is_success());
+    let commit_id = if let envelope::OperationResult::Success { data, .. } = &envelope.result {
+        data.commit_id.clone()
+    } else {
+        panic!("Expected success result");
+    };
+
+    // Verify event in JetStream
+    let client = async_nats::connect(&nats_url()).await?;
+    let js = jetstream::new(client);
+
+    let subject = format!(
+        "demon.graph.v1.{}.{}.{}.commit",
+        scope.tenant_id, scope.project_id, scope.namespace
+    );
+
+    // Wait a bit for event propagation
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let stream = js.get_stream("GRAPH_COMMITS").await?;
+    let consumer = stream
+        .create_consumer(jetstream::consumer::pull::Config {
+            filter_subject: subject.clone(),
+            deliver_policy: DeliverPolicy::All,
+            ack_policy: jetstream::consumer::AckPolicy::None,
+            ..Default::default()
+        })
+        .await?;
+
+    let mut batch = consumer
+        .batch()
+        .max_messages(10)
+        .expires(Duration::from_secs(2))
+        .messages()
+        .await?;
+
+    let mut found_event = false;
+    while let Some(msg) = batch.next().await {
+        let msg = msg.map_err(|e| anyhow::anyhow!("batch error: {}", e))?;
+        let event: serde_json::Value = serde_json::from_slice(&msg.message.payload)?;
+
+        if event["commitId"] == commit_id {
+            found_event = true;
+            assert_eq!(event["event"], "graph.commit.created:v1");
+            assert_eq!(event["graphId"], scope.graph_id);
+            assert_eq!(event["tenantId"], scope.tenant_id);
+            assert!(event["mutations"].is_array());
+            assert_eq!(event["mutations"].as_array().unwrap().len(), 1);
+        }
+    }
+
+    assert!(found_event, "Commit event should appear in stream");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn given_graph_commit_when_mutations_applied_then_deterministic_commit_id() -> Result<()> {
+    // Arrange
+    let scope = GraphScope {
+        tenant_id: "tenant-determinism".to_string(),
+        project_id: "proj-1".to_string(),
+        namespace: "ns-1".to_string(),
+        graph_id: "graph-1".to_string(),
+    };
+
+    let mutations = vec![
+        Mutation::AddNode {
+            node_id: "node-a".to_string(),
+            labels: vec!["Label1".to_string()],
+            properties: vec![],
+        },
+        Mutation::AddNode {
+            node_id: "node-b".to_string(),
+            labels: vec!["Label2".to_string()],
+            properties: vec![],
+        },
+    ];
+
+    // Act - compute commit ID twice
+    let commit_id_1 = graph::compute_commit_id(&scope, None, &mutations);
+    let commit_id_2 = graph::compute_commit_id(&scope, None, &mutations);
+
+    // Assert
+    assert_eq!(commit_id_1, commit_id_2);
+    assert_eq!(commit_id_1.len(), 64); // SHA256 hex
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn given_tag_operation_when_set_then_event_emitted() -> Result<()> {
+    // Arrange
+    let scope = GraphScope {
+        tenant_id: format!("tenant-tag-{}", uuid::Uuid::new_v4()),
+        project_id: "proj-1".to_string(),
+        namespace: "ns-1".to_string(),
+        graph_id: "graph-1".to_string(),
+    };
+
+    let tag_name = "v1.0.0";
+    let commit_id = "a".repeat(64); // Fake commit ID
+
+    // Act
+    let envelope = graph::tag(scope.clone(), tag_name.to_string(), commit_id.clone()).await;
+
+    // Assert
+    assert!(envelope.result.is_success());
+
+    // Verify tag event in JetStream
+    let client = async_nats::connect(&nats_url()).await?;
+    let js = jetstream::new(client);
+
+    let subject = format!(
+        "demon.graph.v1.{}.{}.{}.commit",
+        scope.tenant_id, scope.project_id, scope.namespace
+    );
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let stream = js.get_stream("GRAPH_COMMITS").await?;
+    let consumer = stream
+        .create_consumer(jetstream::consumer::pull::Config {
+            filter_subject: subject.clone(),
+            deliver_policy: DeliverPolicy::All,
+            ack_policy: jetstream::consumer::AckPolicy::None,
+            ..Default::default()
+        })
+        .await?;
+
+    let mut batch = consumer
+        .batch()
+        .max_messages(10)
+        .expires(Duration::from_secs(2))
+        .messages()
+        .await?;
+
+    let mut found_tag_event = false;
+    while let Some(msg) = batch.next().await {
+        let msg = msg.map_err(|e| anyhow::anyhow!("batch error: {}", e))?;
+        let event: serde_json::Value = serde_json::from_slice(&msg.message.payload)?;
+
+        if event["event"] == "graph.tag.updated:v1" && event["tag"] == tag_name {
+            found_tag_event = true;
+            assert_eq!(event["action"], "set");
+            assert_eq!(event["commitId"], commit_id);
+        }
+    }
+
+    assert!(found_tag_event, "Tag event should appear in stream");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn given_commit_with_parent_when_created_then_includes_parent_in_event() -> Result<()> {
+    // Arrange
+    let scope = GraphScope {
+        tenant_id: format!("tenant-parent-{}", uuid::Uuid::new_v4()),
+        project_id: "proj-1".to_string(),
+        namespace: "ns-1".to_string(),
+        graph_id: "graph-1".to_string(),
+    };
+
+    let parent_commit_id = "b".repeat(64);
+    let mutations = vec![Mutation::AddNode {
+        node_id: "child-node".to_string(),
+        labels: vec![],
+        properties: vec![],
+    }];
+
+    // Act
+    let envelope = graph::commit(scope.clone(), Some(parent_commit_id.clone()), mutations).await;
+
+    // Assert
+    assert!(envelope.result.is_success());
+    let commit_id = if let envelope::OperationResult::Success { data, .. } = &envelope.result {
+        assert_eq!(data.parent_commit_id, Some(parent_commit_id.clone()));
+        data.commit_id.clone()
+    } else {
+        panic!("Expected success result");
+    };
+
+    // Verify event has parentCommitId
+    let client = async_nats::connect(&nats_url()).await?;
+    let js = jetstream::new(client);
+
+    let subject = format!(
+        "demon.graph.v1.{}.{}.{}.commit",
+        scope.tenant_id, scope.project_id, scope.namespace
+    );
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let stream = js.get_stream("GRAPH_COMMITS").await?;
+    let consumer = stream
+        .create_consumer(jetstream::consumer::pull::Config {
+            filter_subject: subject,
+            deliver_policy: DeliverPolicy::All,
+            ack_policy: jetstream::consumer::AckPolicy::None,
+            ..Default::default()
+        })
+        .await?;
+
+    let mut batch = consumer
+        .batch()
+        .max_messages(10)
+        .expires(Duration::from_secs(2))
+        .messages()
+        .await?;
+
+    let mut found_event = false;
+    while let Some(msg) = batch.next().await {
+        let msg = msg.map_err(|e| anyhow::anyhow!("batch error: {}", e))?;
+        let event: serde_json::Value = serde_json::from_slice(&msg.message.payload)?;
+
+        if event["commitId"] == commit_id {
+            found_event = true;
+            assert_eq!(event["parentCommitId"], parent_commit_id);
+        }
+    }
+
+    assert!(found_event, "Commit event with parent should appear");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn given_empty_mutations_when_commit_then_returns_error() {
+    // Arrange
+    let scope = GraphScope {
+        tenant_id: "tenant-empty".to_string(),
+        project_id: "proj-1".to_string(),
+        namespace: "ns-1".to_string(),
+        graph_id: "graph-1".to_string(),
+    };
+
+    // Act
+    let envelope = graph::commit(scope, None, vec![]).await;
+
+    // Assert
+    assert!(matches!(
+        envelope.result,
+        envelope::OperationResult::Error { .. }
+    ));
+    assert!(!envelope.diagnostics.is_empty());
+}

--- a/demonctl/Cargo.toml
+++ b/demonctl/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 license.workspace = true
 
 [dependencies]
+capsules_graph = { path = "../capsules/graph" }
 anyhow = { workspace = true }
 clap = { workspace = true }
 tracing = { workspace = true }

--- a/demonctl/src/main.rs
+++ b/demonctl/src/main.rs
@@ -97,6 +97,11 @@ enum Commands {
         #[command(subcommand)]
         cmd: SecretsCommands,
     },
+    /// Graph capsule commands
+    Graph {
+        #[command(subcommand)]
+        cmd: GraphCommands,
+    },
     /// Bootstrap Demon prerequisites (self-host v0)
     Bootstrap {
         /// Profile: local-dev (default) or remote-nats
@@ -223,6 +228,85 @@ enum SecretsCommands {
         /// Secret provider to use (envfile or vault)
         #[arg(long, value_enum, default_value_t = ProviderType::Envfile)]
         provider: ProviderType,
+    },
+}
+
+#[derive(Subcommand)]
+enum GraphCommands {
+    /// Create a new graph with seed mutations
+    Create {
+        /// Tenant ID
+        #[arg(long)]
+        tenant_id: String,
+        /// Project ID
+        #[arg(long)]
+        project_id: String,
+        /// Namespace
+        #[arg(long)]
+        namespace: String,
+        /// Graph ID
+        #[arg(long)]
+        graph_id: String,
+        /// Path to JSON file containing seed mutations
+        #[arg(value_name = "MUTATIONS_FILE")]
+        mutations_file: String,
+    },
+    /// Commit mutations to a graph
+    Commit {
+        /// Tenant ID
+        #[arg(long)]
+        tenant_id: String,
+        /// Project ID
+        #[arg(long)]
+        project_id: String,
+        /// Namespace
+        #[arg(long)]
+        namespace: String,
+        /// Graph ID
+        #[arg(long)]
+        graph_id: String,
+        /// Optional parent commit ID
+        #[arg(long)]
+        parent_ref: Option<String>,
+        /// Path to JSON file containing mutations
+        #[arg(value_name = "MUTATIONS_FILE")]
+        mutations_file: String,
+    },
+    /// Attach or update a tag to point at a commit
+    Tag {
+        /// Tenant ID
+        #[arg(long)]
+        tenant_id: String,
+        /// Project ID
+        #[arg(long)]
+        project_id: String,
+        /// Namespace
+        #[arg(long)]
+        namespace: String,
+        /// Graph ID
+        #[arg(long)]
+        graph_id: String,
+        /// Tag name
+        #[arg(long)]
+        tag: String,
+        /// Commit ID to tag
+        #[arg(long)]
+        commit_id: String,
+    },
+    /// List all tags for a graph
+    ListTags {
+        /// Tenant ID
+        #[arg(long)]
+        tenant_id: String,
+        /// Project ID
+        #[arg(long)]
+        project_id: String,
+        /// Namespace
+        #[arg(long)]
+        namespace: String,
+        /// Graph ID
+        #[arg(long)]
+        graph_id: String,
     },
 }
 
@@ -374,6 +458,9 @@ async fn main() -> Result<()> {
         }
         Commands::Secrets { cmd } => {
             handle_secrets_command(cmd)?;
+        }
+        Commands::Graph { cmd } => {
+            handle_graph_command(cmd).await?;
         }
         Commands::Version => {
             println!("{}", env!("CARGO_PKG_VERSION"));
@@ -2101,6 +2188,107 @@ fn port_forward_and_check(
         }
         Err(e) => anyhow::bail!("Failed to execute curl for health check: {}", e),
     }
+}
+
+async fn handle_graph_command(cmd: GraphCommands) -> Result<()> {
+    match cmd {
+        GraphCommands::Create {
+            tenant_id,
+            project_id,
+            namespace,
+            graph_id,
+            mutations_file,
+        } => {
+            let scope = capsules_graph::GraphScope {
+                tenant_id,
+                project_id,
+                namespace,
+                graph_id,
+            };
+
+            let mutations_json = std::fs::read_to_string(&mutations_file)?;
+            let mutations: Vec<capsules_graph::Mutation> = serde_json::from_str(&mutations_json)?;
+
+            let envelope = capsules_graph::create(scope, mutations).await;
+            let envelope_json = serde_json::to_string_pretty(&envelope)?;
+            println!("{}", envelope_json);
+
+            if !envelope.result.is_success() {
+                std::process::exit(1);
+            }
+        }
+        GraphCommands::Commit {
+            tenant_id,
+            project_id,
+            namespace,
+            graph_id,
+            parent_ref,
+            mutations_file,
+        } => {
+            let scope = capsules_graph::GraphScope {
+                tenant_id,
+                project_id,
+                namespace,
+                graph_id,
+            };
+
+            let mutations_json = std::fs::read_to_string(&mutations_file)?;
+            let mutations: Vec<capsules_graph::Mutation> = serde_json::from_str(&mutations_json)?;
+
+            let envelope = capsules_graph::commit(scope, parent_ref, mutations).await;
+            let envelope_json = serde_json::to_string_pretty(&envelope)?;
+            println!("{}", envelope_json);
+
+            if !envelope.result.is_success() {
+                std::process::exit(1);
+            }
+        }
+        GraphCommands::Tag {
+            tenant_id,
+            project_id,
+            namespace,
+            graph_id,
+            tag,
+            commit_id,
+        } => {
+            let scope = capsules_graph::GraphScope {
+                tenant_id,
+                project_id,
+                namespace,
+                graph_id,
+            };
+
+            let envelope = capsules_graph::tag(scope, tag, commit_id).await;
+            let envelope_json = serde_json::to_string_pretty(&envelope)?;
+            println!("{}", envelope_json);
+
+            if !envelope.result.is_success() {
+                std::process::exit(1);
+            }
+        }
+        GraphCommands::ListTags {
+            tenant_id,
+            project_id,
+            namespace,
+            graph_id,
+        } => {
+            let scope = capsules_graph::GraphScope {
+                tenant_id,
+                project_id,
+                namespace,
+                graph_id,
+            };
+
+            let envelope = capsules_graph::list_tags(scope).await;
+            let envelope_json = serde_json::to_string_pretty(&envelope)?;
+            println!("{}", envelope_json);
+
+            if !envelope.result.is_success() {
+                std::process::exit(1);
+            }
+        }
+    }
+    Ok(())
 }
 
 // no-op: exercise replies guard

--- a/docs/how-to-guides/docker-pipeline.md
+++ b/docs/how-to-guides/docker-pipeline.md
@@ -1,0 +1,120 @@
+# Docker Build & Publish Guide
+
+**📍 [Home](../README.md) › [How-to Guides](README.md) › Docker Build & Publish Guide**
+
+![Status: Current](https://img.shields.io/badge/Status-Current-green)
+
+Build, tag, and publish Demon container images locally and through the GitHub Container Registry (GHCR) workflow.
+
+## Overview
+
+- **Audience**: Demon developers shipping runtime, engine, or operate-ui changes
+- **Goal**: Produce local images for smoke testing and understand the automated GHCR pipeline
+- **Scope**: Local Docker builds, GHCR publishing flow, manual workflow triggers, and smoke test imports
+
+> 🔗 See also: [Docker Troubleshooting & Performance Notes](../ops/docker-troubleshooting.md)
+
+## Prerequisites
+- Docker Engine or Docker Desktop 24.x or newer with BuildKit enabled
+- `docker buildx` plugin (installed automatically with recent Docker releases)
+- Access to the Demon workspace with the Rust toolchain installed (`make build` succeeds)
+- Optional: GitHub CLI (`gh`) for triggering workflows and viewing build logs
+
+Verify your environment:
+
+```bash
+docker version | head -n 1
+docker buildx version
+make build        # ensures workspace compiles before baking images
+```
+
+## Local Image Builds
+
+Each core component ships with a multi-stage Dockerfile in its crate directory.
+
+```bash
+# Build individual component images (linux/amd64)
+docker build -f engine/Dockerfile -t demon-local/engine:dev .
+docker build -f runtime/Dockerfile -t demon-local/runtime:dev .
+docker build -f operate-ui/Dockerfile -t demon-local/operate-ui:dev .
+
+# Optional: multi-platform build with buildx (requires QEMU)
+docker buildx build \
+  --platform linux/amd64,linux/arm64 \
+  -f runtime/Dockerfile \
+  -t demon-local/runtime:multiarch \
+  .
+```
+
+### Import Local Images into Smoke Tests
+
+Set the `LOCAL_IMAGE_IMPORT` environment variable when running `scripts/tests/smoke-k8s-bootstrap.sh` to preload images into the ephemeral k3d cluster:
+
+```bash
+export LOCAL_IMAGE_IMPORT="demon-local/runtime:dev demon-local/engine:dev demon-local/operate-ui:dev"
+scripts/tests/smoke-k8s-bootstrap.sh --verbose --cleanup
+```
+
+The script calls `k3d image import` internally. Provide space-separated image references that are already present in your local Docker cache.
+
+## Automated GHCR Workflow
+
+The GitHub Actions workflow [`docker-build.yml`](../../.github/workflows/docker-build.yml) builds all three images on every pull request and push to `main`.
+
+### Trigger Matrix
+
+| Trigger | Behavior |
+|---------|----------|
+| Pull request touching Dockerfiles/workspace | Builds images, **no push** |
+| Push to `main` | Builds images, pushes tags to GHCR |
+| `workflow_dispatch` | Manual run with the same behavior as the invoked event |
+
+The job matrix builds the `engine`, `runtime`, and `operate-ui` images independently using Docker Buildx with GitHub Actions cache scopes per component.
+
+### Tags and Naming
+
+- Registry prefix: `ghcr.io/afewell-hh/demon-<component>`
+- Tags published on `main` pushes:
+  - `latest` (default branch only)
+  - `sha-<git-sha>` (immutable digest reference)
+  - Branch name aliases (e.g., `main`, `feature/my-fix`)
+- Pull requests receive the same tag set but remain in the workflow cache and are **not** pushed to GHCR.
+
+### Authentication Notes
+
+- The workflow authenticates with `secrets.GITHUB_TOKEN`; no additional PAT is required.
+- For local pushes to GHCR, log in using a personal access token with `write:packages`:
+
+```bash
+docker login ghcr.io -u <github-username> -p <ghcr_pat>
+docker build -f runtime/Dockerfile -t ghcr.io/afewell-hh/demon-runtime:dev .
+docker push ghcr.io/afewell-hh/demon-runtime:dev
+```
+
+### Manual Invocations
+
+```bash
+# Trigger the workflow manually (default inputs)
+gh workflow run docker-build.yml
+
+# Watch build progress
+gh run watch --exit-status --job build --workflow docker-build.yml
+
+# Inspect image metadata emitted by the workflow logs
+gh run view --log $(gh run list --workflow docker-build.yml --limit 1 --json databaseId -q '.[0].databaseId')
+```
+
+## Verification Checklist
+
+- [ ] `make build` completes before building containers
+- [ ] Local `docker build` succeeds for the component you touched
+- [ ] `LOCAL_IMAGE_IMPORT` includes all locally tagged images when running bootstrap smoke tests
+- [ ] GitHub Actions workflow run is green (build job per component)
+- [ ] Image tags are visible under GHCR packages for `afewell-hh`
+
+## Related Resources
+
+- [Docker Troubleshooting & Performance Notes](../ops/docker-troubleshooting.md)
+- [Command Cheat Sheet](../quick-reference/command-cheat-sheet.md)
+- [K8s Bootstrap Smoke Test Script](../../scripts/tests/smoke-k8s-bootstrap.sh)
+- [CI Docker Build Workflow](../../.github/workflows/docker-build.yml)

--- a/docs/ops/README.md
+++ b/docs/ops/README.md
@@ -82,6 +82,46 @@ curl http://localhost:3000/api/runs
 cargo run -p demonctl -- contracts bundle
 ```
 
+### Graph Capsule Operations
+```bash
+# Create a new graph with seed mutations
+demonctl graph create \
+  --tenant-id tenant-1 \
+  --project-id proj-1 \
+  --namespace ns-1 \
+  --graph-id graph-1 \
+  mutations.json
+
+# Commit mutations to an existing graph
+demonctl graph commit \
+  --tenant-id tenant-1 \
+  --project-id proj-1 \
+  --namespace ns-1 \
+  --graph-id graph-1 \
+  --parent-ref <COMMIT_ID> \
+  mutations.json
+
+# Tag a commit
+demonctl graph tag \
+  --tenant-id tenant-1 \
+  --project-id proj-1 \
+  --namespace ns-1 \
+  --graph-id graph-1 \
+  --tag v1.0.0 \
+  --commit-id <COMMIT_ID>
+
+# List tags for a graph
+demonctl graph list-tags \
+  --tenant-id tenant-1 \
+  --project-id proj-1 \
+  --namespace ns-1 \
+  --graph-id graph-1
+
+# Verify graph events in NATS JetStream
+nats stream info GRAPH_COMMITS
+nats stream view GRAPH_COMMITS --count
+```
+
 ## Runbooks
 
 ### Daily Operations

--- a/docs/ops/docker-troubleshooting.md
+++ b/docs/ops/docker-troubleshooting.md
@@ -1,0 +1,120 @@
+# Docker Troubleshooting & Performance
+
+**📍 [Home](../README.md) › [Operations](README.md) › Docker Troubleshooting & Performance**
+
+![Status: Current](https://img.shields.io/badge/Status-Current-green)
+
+Rapid fixes for Docker build failures, GHCR publishing issues, and slow pipeline runs.
+
+## Quick Links
+
+- [Docker Build & Publish Guide](../how-to-guides/docker-pipeline.md)
+- [CI Docker Workflow](../../.github/workflows/docker-build.yml)
+- [Command Cheat Sheet — Docker Section](../quick-reference/command-cheat-sheet.md#docker--containers)
+- Logs directory: `logs/docker-*.log`
+
+## Common Failure Modes
+
+### 1. Cargo Build Failures Inside Docker
+
+**Symptoms:** `error: could not compile` during the `cargo build --release` stage.
+
+**Fix:**
+- Run `make build` locally to surface errors before invoking Docker.
+- Re-run the workflow with a clean cache: `gh workflow run docker-build.yml -f component=runtime --ref <branch>` then retrigger after fixing compile errors.
+- If the failure mentions missing `crate-type`, ensure the crate has a corresponding binary target.
+
+### 2. GHCR Authentication or 403 Errors
+
+**Symptoms:** `failed to fetch anonymous token: unexpected status: 403 Forbidden`.
+
+**Fix:**
+- **CI:** Authentication uses `GITHUB_TOKEN` automatically. Verify Packages: write permission in workflow logs.
+- **Local push:**
+  ```bash
+  docker login ghcr.io -u <github-username>
+  docker tag demon-local/runtime:dev ghcr.io/afewell-hh/demon-runtime:dev
+  docker push ghcr.io/afewell-hh/demon-runtime:dev
+  ```
+- Check GHCR status page when failures cluster across jobs.
+- See `GHCR_FIX_SUMMARY.md` for historical context and mitigations.
+
+### 3. Cache Misses & Slow Rebuilds
+
+**Symptoms:** Build job exceeds 60 minutes, repeated dependency compilation.
+
+**Fix:**
+- Confirm cache hits in logs: search for `Using cache` sections in the Buildx step.
+- Warm caches by running the workflow on a feature branch before merging to `main`.
+- Avoid force-pushing large dependency changes; incremental merges preserve cache layers.
+- For local builds, mount cargo cache:
+  ```bash
+  docker build \
+    --build-arg CARGO_HOME=/workspace/.cargo \
+    -f runtime/Dockerfile .
+  ```
+
+### 4. Smoke Test Pull Failures
+
+**Symptoms:** `ImagePullBackOff` in `scripts/tests/smoke-k8s-bootstrap.sh`.
+
+**Fix:**
+- Ensure GHCR images exist: `docker manifest inspect ghcr.io/afewell-hh/demon-runtime:main`.
+- Provide pre-built locals when iterating quickly:
+  ```bash
+  export LOCAL_IMAGE_IMPORT="demon-local/runtime:dev demon-local/engine:dev demon-local/operate-ui:dev"
+  scripts/tests/smoke-k8s-bootstrap.sh --verbose --cleanup
+  ```
+- For private registries, extend bootstrap config with `registries[]` as documented in `GHCR_FIX_SUMMARY.md`.
+
+### 5. Buildx Builder Drift
+
+**Symptoms:** `failed to find builder` or mismatched BuildKit version.
+
+**Fix:**
+- Remove stale builders locally: `docker buildx rm $(docker buildx ls | awk '/demon/{print $1}')`.
+- Reset builder inside CI rerun (workflow step already removes builder on cleanup). If drift persists, re-run with `workflow_dispatch`.
+
+## Performance Benchmarks (Alpha Preview)
+
+| Run ID | Date (UTC) | Context | Runtime | Engine | Operate UI |
+|--------|------------|---------|---------|--------|------------|
+| 17964002949 | 2025-09-24 | First GHCR publish (cold cache) | 64.3 min | 64.9 min | 78.5 min |
+| 18020300302 | 2025-09-25 | PR validation (warm cache) | 6.9 min | 6.8 min | 10.8 min |
+
+**Takeaways:**
+- Expect the first push after massive dependency updates to take over an hour.
+- Warmed caches bring total matrix wall-clock under 15 minutes.
+- Cache scope is per component (`scope=${{ matrix.component }}`), so touching only one crate keeps other images fast.
+
+## Image Size Snapshot (linux/amd64)
+
+| Component | Digest | Compressed Size |
+|-----------|--------|----------------|
+| Runtime | `sha256:d106f63b…eca53` | ≈1.9 MiB |
+| Engine | `sha256:c47cee22…a5c6` | ≈1.9 MiB |
+| Operate UI | `sha256:7ddea572…316f` | ≈10.1 MiB |
+
+**How to verify:**
+```bash
+docker manifest inspect ghcr.io/afewell-hh/demon-runtime:main | jq '.manifests[0].digest'
+docker manifest inspect ghcr.io/afewell-hh/demon-runtime@sha256:<digest> | jq '.layers[].size'
+```
+
+## Diagnostic Commands
+
+- Tail latest workflow logs: `rg --no-heading -n "error:" logs/docker-*.log`
+- Inspect GHCR tags: `gh api /orgs/afewell-hh/packages/container/demon-runtime/versions`
+- Verify Buildx builder: `docker buildx inspect --bootstrap`
+- Confirm cache key usage: `rg "cache-from" -n .github/workflows/docker-build.yml`
+
+## Escalation Checklist
+
+1. Capture failing workflow URL and attach relevant `logs/docker-*.log` snippet.
+2. Note whether `docker-build.yml` ran from PR or `main` (push enables pushes).
+3. Include digests from the last successful run (`logs/docker-publish-*.log`).
+4. Update `docs/releases/README-HANDOFF.md` if production manifests are blocked.
+
+---
+
+**Next steps when blockers persist:** open Issue #186 (or successor) with logs attached, ping platform lead on Slack, and rerun `docker-build.yml` once root cause is resolved.

--- a/docs/quick-reference/command-cheat-sheet.md
+++ b/docs/quick-reference/command-cheat-sheet.md
@@ -24,6 +24,9 @@ cargo run -p demonctl -- run examples/rituals/echo.yaml
 
 # Graph capsule tests
 cargo test -p capsules_graph
+
+# Runtime graph dispatch tests
+cargo test -p runtime --test graph_dispatch_spec
 ```
 
 ## Docker & Containers
@@ -109,6 +112,10 @@ kubectl logs -n demon-system deployment/demon-runtime
 nats-cli stream ls
 nats-cli consumer ls RITUAL_EVENTS
 
+# Graph capsule: Check JetStream events
+nats stream info GRAPH_COMMITS
+nats stream view GRAPH_COMMITS
+
 # Debug networking
 kubectl port-forward -n demon-system svc/demon-engine 3000:3000
 ```
@@ -122,6 +129,43 @@ kubectl port-forward -n demon-system svc/demon-engine 3000:3000
 | **API not responding** | `curl localhost:3000/api/runs` | JSON response |
 | **NATS issues** | `nats-cli stream ls` | Shows RITUAL_EVENTS |
 | **Pod crashes** | `kubectl get pods` | All pods Running |
+
+## Graph Commands
+
+```bash
+# Create graph with seed mutations
+demonctl graph create \
+  --tenant-id tenant-1 \
+  --project-id proj-1 \
+  --namespace ns-1 \
+  --graph-id graph-1 \
+  mutations.json
+
+# Commit mutations
+demonctl graph commit \
+  --tenant-id tenant-1 \
+  --project-id proj-1 \
+  --namespace ns-1 \
+  --graph-id graph-1 \
+  --parent-ref <COMMIT_ID> \
+  mutations.json
+
+# Tag a commit
+demonctl graph tag \
+  --tenant-id tenant-1 \
+  --project-id proj-1 \
+  --namespace ns-1 \
+  --graph-id graph-1 \
+  --tag v1.0.0 \
+  --commit-id <COMMIT_ID>
+
+# List tags
+demonctl graph list-tags \
+  --tenant-id tenant-1 \
+  --project-id proj-1 \
+  --namespace ns-1 \
+  --graph-id graph-1
+```
 
 ## Environment Variables
 

--- a/docs/quick-reference/command-cheat-sheet.md
+++ b/docs/quick-reference/command-cheat-sheet.md
@@ -21,6 +21,9 @@ make fmt && make lint
 
 # Quick smoke test
 cargo run -p demonctl -- run examples/rituals/echo.yaml
+
+# Graph capsule tests
+cargo test -p capsules_graph
 ```
 
 ## Docker & Containers

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -19,6 +19,7 @@ serde_json = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 capsules_echo = { path = "../capsules/echo" }
+capsules_graph = { path = "../capsules/graph" }
 async-nats = { workspace = true }
 tokio = { workspace = true }
 chrono = { workspace = true }
@@ -28,3 +29,5 @@ sha2 = "0.10"
 
 [dev-dependencies]
 tempfile = "3.8"
+uuid = { workspace = true }
+futures-util = { workspace = true }

--- a/runtime/src/link/router.rs
+++ b/runtime/src/link/router.rs
@@ -164,6 +164,16 @@ impl Router {
                 let envelope = capsules_graph::tag(scope, tag, commit_id).await;
                 Ok(serde_json::to_value(envelope)?)
             }
+            "delete-tag" => {
+                let tag = args
+                    .get("tag")
+                    .and_then(|v| v.as_str())
+                    .ok_or_else(|| anyhow::anyhow!("Missing 'tag' field for delete-tag operation"))?
+                    .to_string();
+
+                let envelope = capsules_graph::delete_tag(scope, tag).await;
+                Ok(serde_json::to_value(envelope)?)
+            }
             "list-tags" => {
                 let envelope = capsules_graph::list_tags(scope).await;
                 Ok(serde_json::to_value(envelope)?)

--- a/runtime/tests/graph_dispatch_spec.rs
+++ b/runtime/tests/graph_dispatch_spec.rs
@@ -1,0 +1,306 @@
+//! Runtime integration tests for graph capsule dispatch
+//!
+//! These tests verify that the runtime router can dispatch graph operations
+//! and that events are emitted to JetStream.
+
+use anyhow::Result;
+use async_nats::jetstream;
+use futures_util::StreamExt;
+use runtime::link::router::Router;
+use serde_json::json;
+use std::time::Duration;
+
+fn nats_url() -> String {
+    std::env::var("NATS_URL").unwrap_or_else(|_| "nats://127.0.0.1:4222".to_string())
+}
+
+#[tokio::test]
+async fn given_graph_create_via_runtime_when_dispatched_then_commit_event_emitted() -> Result<()> {
+    // Arrange
+    let router = Router::new();
+    let tenant_id = format!("tenant-{}", uuid::Uuid::new_v4());
+
+    let args = json!({
+        "operation": "create",
+        "scope": {
+            "tenantId": tenant_id,
+            "projectId": "proj-1",
+            "namespace": "ns-1",
+            "graphId": "graph-1"
+        },
+        "seed": [
+            {
+                "op": "add-node",
+                "nodeId": "root",
+                "labels": ["Root"],
+                "properties": []
+            }
+        ]
+    });
+
+    // Act
+    let result = router
+        .dispatch("graph", &args, "test-run", "test-ritual")
+        .await?;
+
+    // Assert - envelope is success
+    let envelope_value = result;
+    assert!(envelope_value["result"]["status"].as_str() == Some("success"));
+    let commit_id = envelope_value["result"]["data"]["commitId"]
+        .as_str()
+        .expect("Should have commit ID");
+
+    // Verify event in JetStream
+    let client = async_nats::connect(&nats_url()).await?;
+    let js = jetstream::new(client);
+
+    let subject = format!("demon.graph.v1.{}.proj-1.ns-1.commit", tenant_id);
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let stream = js.get_stream("GRAPH_COMMITS").await?;
+    let consumer = stream
+        .create_consumer(jetstream::consumer::pull::Config {
+            filter_subject: subject,
+            deliver_policy: jetstream::consumer::DeliverPolicy::All,
+            ack_policy: jetstream::consumer::AckPolicy::None,
+            ..Default::default()
+        })
+        .await?;
+
+    let mut batch = consumer
+        .batch()
+        .max_messages(10)
+        .expires(Duration::from_secs(2))
+        .messages()
+        .await?;
+
+    let mut found_event = false;
+    while let Some(msg) = batch.next().await {
+        let msg = msg?;
+        let event: serde_json::Value = serde_json::from_slice(&msg.message.payload)?;
+
+        if event["commitId"] == commit_id {
+            found_event = true;
+            assert_eq!(event["event"], "graph.commit.created:v1");
+            assert_eq!(event["graphId"], "graph-1");
+            assert_eq!(event["tenantId"], tenant_id);
+        }
+    }
+
+    assert!(found_event, "Commit event should appear in stream");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn given_graph_commit_via_runtime_when_dispatched_then_event_has_parent() -> Result<()> {
+    // Arrange
+    let router = Router::new();
+    let tenant_id = format!("tenant-{}", uuid::Uuid::new_v4());
+    let parent_commit_id = "a".repeat(64);
+
+    let args = json!({
+        "operation": "commit",
+        "scope": {
+            "tenantId": tenant_id,
+            "projectId": "proj-1",
+            "namespace": "ns-1",
+            "graphId": "graph-1"
+        },
+        "parentRef": parent_commit_id,
+        "mutations": [
+            {
+                "op": "add-node",
+                "nodeId": "child",
+                "labels": [],
+                "properties": []
+            }
+        ]
+    });
+
+    // Act
+    let result = router
+        .dispatch("graph", &args, "test-run", "test-ritual")
+        .await?;
+
+    // Assert
+    let envelope_value = result;
+    assert!(envelope_value["result"]["status"].as_str() == Some("success"));
+    let commit_id = envelope_value["result"]["data"]["commitId"]
+        .as_str()
+        .expect("Should have commit ID");
+    let returned_parent = envelope_value["result"]["data"]["parentCommitId"]
+        .as_str()
+        .expect("Should have parent commit ID");
+    assert_eq!(returned_parent, parent_commit_id);
+
+    // Verify event has parentCommitId
+    let client = async_nats::connect(&nats_url()).await?;
+    let js = jetstream::new(client);
+
+    let subject = format!("demon.graph.v1.{}.proj-1.ns-1.commit", tenant_id);
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let stream = js.get_stream("GRAPH_COMMITS").await?;
+    let consumer = stream
+        .create_consumer(jetstream::consumer::pull::Config {
+            filter_subject: subject,
+            deliver_policy: jetstream::consumer::DeliverPolicy::All,
+            ack_policy: jetstream::consumer::AckPolicy::None,
+            ..Default::default()
+        })
+        .await?;
+
+    let mut batch = consumer
+        .batch()
+        .max_messages(10)
+        .expires(Duration::from_secs(2))
+        .messages()
+        .await?;
+
+    let mut found_event = false;
+    while let Some(msg) = batch.next().await {
+        let msg = msg?;
+        let event: serde_json::Value = serde_json::from_slice(&msg.message.payload)?;
+
+        if event["commitId"] == commit_id {
+            found_event = true;
+            assert_eq!(event["parentCommitId"], parent_commit_id);
+        }
+    }
+
+    assert!(found_event, "Commit event with parent should appear");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn given_graph_tag_via_runtime_when_dispatched_then_tag_event_emitted() -> Result<()> {
+    // Arrange
+    let router = Router::new();
+    let tenant_id = format!("tenant-{}", uuid::Uuid::new_v4());
+    let commit_id = "b".repeat(64);
+    let tag = "v1.0.0";
+
+    let args = json!({
+        "operation": "tag",
+        "scope": {
+            "tenantId": tenant_id,
+            "projectId": "proj-1",
+            "namespace": "ns-1",
+            "graphId": "graph-1"
+        },
+        "tag": tag,
+        "commitId": commit_id
+    });
+
+    // Act
+    let result = router
+        .dispatch("graph", &args, "test-run", "test-ritual")
+        .await?;
+
+    // Assert
+    let envelope_value = result;
+    assert!(envelope_value["result"]["status"].as_str() == Some("success"));
+
+    // Verify tag event in JetStream
+    let client = async_nats::connect(&nats_url()).await?;
+    let js = jetstream::new(client);
+
+    let subject = format!("demon.graph.v1.{}.proj-1.ns-1.commit", tenant_id);
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let stream = js.get_stream("GRAPH_COMMITS").await?;
+    let consumer = stream
+        .create_consumer(jetstream::consumer::pull::Config {
+            filter_subject: subject,
+            deliver_policy: jetstream::consumer::DeliverPolicy::All,
+            ack_policy: jetstream::consumer::AckPolicy::None,
+            ..Default::default()
+        })
+        .await?;
+
+    let mut batch = consumer
+        .batch()
+        .max_messages(10)
+        .expires(Duration::from_secs(2))
+        .messages()
+        .await?;
+
+    let mut found_event = false;
+    while let Some(msg) = batch.next().await {
+        let msg = msg?;
+        let event: serde_json::Value = serde_json::from_slice(&msg.message.payload)?;
+
+        if event["event"] == "graph.tag.updated:v1" && event["tag"] == tag {
+            found_event = true;
+            assert_eq!(event["action"], "set");
+            assert_eq!(event["commitId"], commit_id);
+        }
+    }
+
+    assert!(found_event, "Tag event should appear in stream");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn given_list_tags_via_runtime_when_dispatched_then_returns_placeholder() -> Result<()> {
+    // Arrange
+    let router = Router::new();
+
+    let args = json!({
+        "operation": "list-tags",
+        "scope": {
+            "tenantId": "tenant-1",
+            "projectId": "proj-1",
+            "namespace": "ns-1",
+            "graphId": "graph-1"
+        }
+    });
+
+    // Act
+    let result = router
+        .dispatch("graph", &args, "test-run", "test-ritual")
+        .await?;
+
+    // Assert - should succeed but return empty (placeholder)
+    let envelope_value = result;
+    assert!(envelope_value["result"]["status"].as_str() == Some("success"));
+    assert!(envelope_value["result"]["data"].is_array());
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn given_get_node_via_runtime_when_dispatched_then_returns_not_implemented() -> Result<()> {
+    // Arrange
+    let router = Router::new();
+
+    let args = json!({
+        "operation": "get-node",
+        "scope": {
+            "tenantId": "tenant-1",
+            "projectId": "proj-1",
+            "namespace": "ns-1",
+            "graphId": "graph-1"
+        },
+        "commitId": "c".repeat(64),
+        "nodeId": "node-1"
+    });
+
+    // Act
+    let result = router
+        .dispatch("graph", &args, "test-run", "test-ritual")
+        .await?;
+
+    // Assert - should return error with NOT_IMPLEMENTED
+    let envelope_value = result;
+    assert!(envelope_value["result"]["status"].as_str() == Some("error"));
+    assert!(envelope_value["result"]["error"]["code"] == "NOT_IMPLEMENTED");
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- Implement GRAPH_TAGS KV bucket for tag persistence and retrieval
- Add put_tag(), delete_tag(), list_tags() storage helpers with namespaced keys
- Update tag() to persist to KV, add delete_tag() operation
- Wire delete-tag through runtime router, add integration tests
- Capsule tests pass (9/9), verifying KV create/read/delete/list operations

## Testing
- `cargo test -p capsules_graph`: All 9 tests pass
- New tests verify:
  - Tag KV persistence after set operation
  - Tag removal via delete_tag()  
  - list_tags() returns sorted entries
  - Non-existent tag deletion returns error
- Runtime tests updated (batch error handling fixed for async-nats API)

## Follow-on
- Runtime dispatch tests have pre-existing failures (likely from base branch)
- CLI integration (if needed) deferred

Review-lock: 8c352c178a09c3f33af37248f03b41e2379e84dd

---
Closes #207 (if tracking issue exists)
Relates to PR #209 (graph capsule foundation) and EPIC 4 (graph tag persistence)