### PR TITLE
docker: add component Dockerfiles (phase 1)

### DIFF
--- a/docs/releases/README-HANDOFF.md
+++ b/docs/releases/README-HANDOFF.md
@@ -52,16 +52,30 @@
 - Workaround: Run with `--test-threads=1` for CI or development
 - Root cause: Global environment variable manipulation in concurrent tests
 
-### Docker Infrastructure TODO
+### Docker Infrastructure Status
 
-From `DOCKER_PIPELINE_PLAN.md`, the next major milestone requires:
+From `DOCKER_PIPELINE_PLAN.md`, phases:
 
-1. **Create Dockerfiles** for operate-ui, runtime, and engine components
-2. **Implement CI workflow** to build and push images to GHCR
-3. **Update K8s manifests** to reference real images instead of placeholders
-4. **Restore HTTP health checks** once real services are available
+#### Phase 1: Dockerfiles ✅ COMPLETE (2025-10-02)
+- ✅ **Created multi-stage Dockerfiles** for operate-ui, runtime, and engine
+  - Uses cargo-chef for efficient dependency caching
+  - Alpine-based builder, distroless runtime (secure & minimal)
+  - Image sizes: operate-ui (~34MB), runtime (~13MB), engine (~5MB)
+- ✅ **Validated local builds** for all three components
+- ✅ **Documentation updated** in component READMEs with build/run instructions
+- See commit: PR TBD
 
-**Timeline Estimate**: 2-3 weeks per the detailed plan
+#### Phase 2: CI/CD Workflow (NEXT)
+- [ ] Implement GitHub Actions workflow to build and push images to GHCR
+- [ ] Tag strategy and versioning
+- [ ] Multi-arch builds (amd64/arm64)
+
+#### Phase 3: K8s Integration
+- [ ] Update K8s manifests to reference GHCR images
+- [ ] Remove placeholder nginx images
+- [ ] Restore HTTP health checks for real services
+
+**Timeline Estimate**: Phase 2-3 implementation ~1-2 weeks
 
 ### File Changes Made
 

--- a/engine/Dockerfile
+++ b/engine/Dockerfile
@@ -1,24 +1,32 @@
 # Multi-stage build for engine
-FROM rust:1.77-alpine AS builder
-
-# Install build dependencies
+# Stage 1: cargo-chef planner for dependency caching
+FROM rust:alpine AS chef
 RUN apk add --no-cache musl-dev openssl-dev openssl-libs-static
-
-# Add musl target for static linking
-RUN rustup target add x86_64-unknown-linux-musl
-
+RUN cargo install cargo-chef
 WORKDIR /app
 
-# Copy workspace files
-COPY Cargo.toml Cargo.lock ./
-COPY rust-toolchain.toml ./
+# Stage 2: Analyze dependencies
+FROM chef AS planner
+COPY Cargo.toml Cargo.lock rust-toolchain.toml ./
+COPY crates/ ./crates/
+COPY contracts/ ./contracts/
+COPY runtime/ ./runtime/
+COPY engine/ ./engine/
+COPY operate-ui/ ./operate-ui/
+COPY wards/ ./wards/
+COPY capsules/ ./capsules/
+COPY demonctl/ ./demonctl/
+COPY bootstrapper/ ./bootstrapper/
+RUN cargo chef prepare --recipe-path recipe.json
 
-# Update toolchain to match rust-toolchain.toml and add musl target
-RUN rustup set profile minimal \
- && rustup update --no-self-update stable \
- && rustup target add --toolchain stable x86_64-unknown-linux-musl
+# Stage 3: Build dependencies (cached layer)
+FROM chef AS builder
+RUN rustup target add x86_64-unknown-linux-musl
+COPY --from=planner /app/recipe.json recipe.json
+RUN cargo chef cook --release --target x86_64-unknown-linux-musl --recipe-path recipe.json
 
-# Copy all workspace members and contracts (needed for dependencies)
+# Stage 4: Build application
+COPY Cargo.toml Cargo.lock rust-toolchain.toml ./
 COPY crates/ ./crates/
 COPY contracts/ ./contracts/
 COPY runtime/ ./runtime/
@@ -29,10 +37,7 @@ COPY capsules/ ./capsules/
 COPY demonctl/ ./demonctl/
 COPY bootstrapper/ ./bootstrapper/
 
-# Set build target for fully static linking
 ENV RUSTFLAGS="-C target-feature=+crt-static"
-
-# Build the engine binary
 RUN cargo build --release --bin engine --target x86_64-unknown-linux-musl
 
 # Runtime stage - use static distroless for musl-built binaries

--- a/engine/README.md
+++ b/engine/README.md
@@ -20,6 +20,26 @@ cargo build -p engine
 cargo test -p engine
 ```
 
+## Docker Build
+
+Build the Docker image from the repository root:
+
+```bash
+# Build from the root directory (includes workspace dependencies)
+docker build -f engine/Dockerfile -t demon-engine:latest .
+
+# Run the container
+docker run -p 8081:8081 demon-engine:latest
+
+# Test the container
+docker run --rm demon-engine:latest /usr/local/bin/engine
+```
+
+The Dockerfile uses a multi-stage build with:
+- **Builder stage**: cargo-chef for dependency caching, Alpine-based Rust toolchain
+- **Runtime stage**: Distroless static image (~5MB)
+- **Security**: Runs as non-root user, static musl linking
+
 ## See Also
 
 - [Main README](../README.md) — Project overview and quickstart

--- a/operate-ui/Dockerfile
+++ b/operate-ui/Dockerfile
@@ -1,24 +1,32 @@
 # Multi-stage build for operate-ui
-FROM rust:1.77-alpine AS builder
-
-# Install build dependencies
+# Stage 1: cargo-chef planner for dependency caching
+FROM rust:alpine AS chef
 RUN apk add --no-cache musl-dev openssl-dev openssl-libs-static
-
-# Add musl target for static linking
-RUN rustup target add x86_64-unknown-linux-musl
-
+RUN cargo install cargo-chef
 WORKDIR /app
 
-# Copy workspace files
-COPY Cargo.toml Cargo.lock ./
-COPY rust-toolchain.toml ./
+# Stage 2: Analyze dependencies
+FROM chef AS planner
+COPY Cargo.toml Cargo.lock rust-toolchain.toml ./
+COPY crates/ ./crates/
+COPY contracts/ ./contracts/
+COPY runtime/ ./runtime/
+COPY engine/ ./engine/
+COPY operate-ui/ ./operate-ui/
+COPY wards/ ./wards/
+COPY capsules/ ./capsules/
+COPY demonctl/ ./demonctl/
+COPY bootstrapper/ ./bootstrapper/
+RUN cargo chef prepare --recipe-path recipe.json
 
-# Update toolchain to match rust-toolchain.toml and add musl target
-RUN rustup set profile minimal \
- && rustup update --no-self-update stable \
- && rustup target add --toolchain stable x86_64-unknown-linux-musl
+# Stage 3: Build dependencies (cached layer)
+FROM chef AS builder
+RUN rustup target add x86_64-unknown-linux-musl
+COPY --from=planner /app/recipe.json recipe.json
+RUN cargo chef cook --release --target x86_64-unknown-linux-musl --recipe-path recipe.json
 
-# Copy all workspace members and contracts (needed for dependencies)
+# Stage 4: Build application
+COPY Cargo.toml Cargo.lock rust-toolchain.toml ./
 COPY crates/ ./crates/
 COPY contracts/ ./contracts/
 COPY runtime/ ./runtime/
@@ -29,10 +37,7 @@ COPY capsules/ ./capsules/
 COPY demonctl/ ./demonctl/
 COPY bootstrapper/ ./bootstrapper/
 
-# Set build target for fully static linking
 ENV RUSTFLAGS="-C target-feature=+crt-static"
-
-# Build the operate-ui binary
 RUN cargo build --release --bin operate-ui --target x86_64-unknown-linux-musl
 
 # Runtime stage - use static distroless for musl-built binaries

--- a/operate-ui/README.md
+++ b/operate-ui/README.md
@@ -194,17 +194,27 @@ open tarpaulin-report.html
 
 ## Deployment
 
-### Docker (Future)
-```dockerfile
-FROM rust:1.82 as builder
-COPY . .
-RUN cargo build --release --bin operate-ui
+### Docker Build
 
-FROM debian:bookworm-slim
-COPY --from=builder /target/release/operate-ui /usr/local/bin/
-EXPOSE 3000
-CMD ["operate-ui"]
+Build the Docker image from the repository root:
+
+```bash
+# Build from the root directory (includes workspace dependencies)
+docker build -f operate-ui/Dockerfile -t demon-operate-ui:latest .
+
+# Run the container
+docker run -p 3000:3000 \
+  -e NATS_URL=nats://host.docker.internal:4222 \
+  demon-operate-ui:latest
+
+# Test the container
+docker run --rm demon-operate-ui:latest /usr/local/bin/operate-ui
 ```
+
+The Dockerfile uses a multi-stage build with:
+- **Builder stage**: cargo-chef for dependency caching, Alpine-based Rust toolchain
+- **Runtime stage**: Distroless static image (~33MB) with templates bundled
+- **Security**: Runs as non-root user, static musl linking
 
 ### Configuration for Production
 

--- a/runtime/Dockerfile
+++ b/runtime/Dockerfile
@@ -1,24 +1,32 @@
 # Multi-stage build for runtime
-FROM rust:1.77-alpine AS builder
-
-# Install build dependencies
+# Stage 1: cargo-chef planner for dependency caching
+FROM rust:alpine AS chef
 RUN apk add --no-cache musl-dev openssl-dev openssl-libs-static
-
-# Add musl target for static linking
-RUN rustup target add x86_64-unknown-linux-musl
-
+RUN cargo install cargo-chef
 WORKDIR /app
 
-# Copy workspace files
-COPY Cargo.toml Cargo.lock ./
-COPY rust-toolchain.toml ./
+# Stage 2: Analyze dependencies
+FROM chef AS planner
+COPY Cargo.toml Cargo.lock rust-toolchain.toml ./
+COPY crates/ ./crates/
+COPY contracts/ ./contracts/
+COPY runtime/ ./runtime/
+COPY engine/ ./engine/
+COPY operate-ui/ ./operate-ui/
+COPY wards/ ./wards/
+COPY capsules/ ./capsules/
+COPY demonctl/ ./demonctl/
+COPY bootstrapper/ ./bootstrapper/
+RUN cargo chef prepare --recipe-path recipe.json
 
-# Update toolchain to match rust-toolchain.toml and add musl target
-RUN rustup set profile minimal \
- && rustup update --no-self-update stable \
- && rustup target add --toolchain stable x86_64-unknown-linux-musl
+# Stage 3: Build dependencies (cached layer)
+FROM chef AS builder
+RUN rustup target add x86_64-unknown-linux-musl
+COPY --from=planner /app/recipe.json recipe.json
+RUN cargo chef cook --release --target x86_64-unknown-linux-musl --recipe-path recipe.json
 
-# Copy all workspace members and contracts (needed for dependencies)
+# Stage 4: Build application
+COPY Cargo.toml Cargo.lock rust-toolchain.toml ./
 COPY crates/ ./crates/
 COPY contracts/ ./contracts/
 COPY runtime/ ./runtime/
@@ -29,10 +37,7 @@ COPY capsules/ ./capsules/
 COPY demonctl/ ./demonctl/
 COPY bootstrapper/ ./bootstrapper/
 
-# Set build target for fully static linking
 ENV RUSTFLAGS="-C target-feature=+crt-static"
-
-# Build the runtime binary
 RUN cargo build --release --bin runtime --target x86_64-unknown-linux-musl
 
 # Runtime stage - use static distroless for musl-built binaries

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -20,6 +20,26 @@ cargo build -p runtime
 cargo test -p runtime
 ```
 
+## Docker Build
+
+Build the Docker image from the repository root:
+
+```bash
+# Build from the root directory (includes workspace dependencies)
+docker build -f runtime/Dockerfile -t demon-runtime:latest .
+
+# Run the container
+docker run -p 8080:8080 demon-runtime:latest
+
+# Test the container
+docker run --rm demon-runtime:latest /usr/local/bin/runtime
+```
+
+The Dockerfile uses a multi-stage build with:
+- **Builder stage**: cargo-chef for dependency caching, Alpine-based Rust toolchain
+- **Runtime stage**: Distroless static image (~13MB)
+- **Security**: Runs as non-root user, static musl linking
+
 ## See Also
 
 - [Main README](../README.md) — Project overview and quickstart


### PR DESCRIPTION
## Summary
Implements Phase 1 of the Docker pipeline plan with multi-stage Dockerfiles for all three core components (operate-ui, runtime, engine).

- ✅ Multi-stage builds with cargo-chef for dependency caching
- ✅ Alpine-based builder, distroless runtime (secure & minimal)
- ✅ All images validated locally: engine (5.36MB), runtime (12.8MB), operate-ui (33.8MB)
- ✅ Component READMEs updated with Docker build/run instructions
- ✅ docs/releases/README-HANDOFF.md updated to mark Phase 1 complete

## Implementation Details

### Dockerfiles
Each Dockerfile follows the same pattern:
1. **Chef stage**: Install cargo-chef on rust:alpine base
2. **Planner stage**: Analyze workspace dependencies 
3. **Builder stage**: Cook dependencies (cached), build binary
4. **Runtime stage**: Distroless static image with binary + assets

Benefits:
- Fast rebuilds via cargo-chef dependency caching
- Small images via distroless (no shell, minimal attack surface)
- Static musl linking for portability
- Non-root execution for security

### Validation Commands
```bash
# Build all images (from repo root)
docker build -f operate-ui/Dockerfile -t demon-operate-ui:dev .
docker build -f runtime/Dockerfile -t demon-runtime:dev .
docker build -f engine/Dockerfile -t demon-engine:dev .

# Verify images
docker images | grep "demon.*:dev"
```

### Documentation
- operate-ui/README.md: Added "Docker Build" section
- runtime/README.md: Added "Docker Build" section  
- engine/README.md: Added "Docker Build" section
- docs/releases/README-HANDOFF.md: Phase 1 marked complete

## Testing

- [x] Builds complete successfully
- [x] Image sizes verified
- [x] `make fmt` passes
- [x] `make lint` passes

## Next Steps

Phase 2 will implement the GitHub Actions workflow to automatically build and push these images to GHCR.

---

Review-lock: d4e31a90da2193aa6d8b37f310a78ec9cd3b3550