### PR TITLE
k8s: render ghcr images via configurable tags

### DIFF
--- a/.github/workflows/bootstrapper-smoke.yml
+++ b/.github/workflows/bootstrapper-smoke.yml
@@ -7,8 +7,66 @@ on:
   workflow_dispatch: {}
 
 jobs:
+  resolve-digests:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+    outputs:
+      digest-json: ${{ steps.fetch.outputs.digest-json }}
+      operate-ui-tag: ${{ steps.fetch.outputs.operate-ui-tag }}
+      runtime-tag: ${{ steps.fetch.outputs.runtime-tag }}
+      engine-tag: ${{ steps.fetch.outputs.engine-tag }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust (pinned toolchain)
+        uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: 1.82.0
+
+      - name: Cache cargo registry + target
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            .
+          cache-on-failure: true
+
+      - name: Install jq
+        run: sudo apt-get update && sudo apt-get install -y jq
+
+      - name: Install demonctl CLI
+        run: cargo install --path demonctl --locked --force
+
+      - name: Fetch docker image digests with demonctl
+        id: fetch
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DEMONCTL_GITHUB_REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          BIN="$HOME/.cargo/bin/demonctl"
+          MANIFEST_PATH="$RUNNER_TEMP/docker-image-digests.json"
+          ENV_EXPORTS="$($BIN docker digests fetch --format env --output "$MANIFEST_PATH")"
+
+          eval "$ENV_EXPORTS"
+
+          digest_json=$(jq -c . "$MANIFEST_PATH")
+          echo "digest-json=$digest_json" >> "$GITHUB_OUTPUT"
+          echo "operate-ui-tag=$OPERATE_UI_IMAGE_TAG" >> "$GITHUB_OUTPUT"
+          echo "runtime-tag=$RUNTIME_IMAGE_TAG" >> "$GITHUB_OUTPUT"
+          echo "engine-tag=$ENGINE_IMAGE_TAG" >> "$GITHUB_OUTPUT"
+
+          {
+            echo "### Resolved docker-build manifest"
+            echo ""
+            jq -r 'to_entries | ("| Component | Image |"), ("| --- | --- |"), (.[] | "| " + .key + " | `" + .value.image + "` |")' "$MANIFEST_PATH"
+          } >> "$GITHUB_STEP_SUMMARY"
+
   k8s-bootstrapper-smoke-full:
     runs-on: ubuntu-latest
+    needs: resolve-digests
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -37,11 +95,23 @@ jobs:
       - name: Build workspace
         run: cargo build --workspace
 
-      - name: Build runtime image for smoke test
-        run: docker build -f runtime/Dockerfile -t ghcr.io/afewell-hh/demon-runtime:main .
+      - name: Export GHCR image tags for smoke test
+        run: |
+          {
+            echo "OPERATE_UI_IMAGE_TAG=${{ needs.resolve-digests.outputs.operate-ui-tag }}"
+            echo "RUNTIME_IMAGE_TAG=${{ needs.resolve-digests.outputs.runtime-tag }}"
+            echo "ENGINE_IMAGE_TAG=${{ needs.resolve-digests.outputs.engine-tag }}"
+          } >> "$GITHUB_ENV"
 
-      - name: Build engine image for smoke test
-        run: docker build -f engine/Dockerfile -t ghcr.io/afewell-hh/demon-engine:main .
+          {
+            echo "### Scheduled smoke image digests"
+            echo ""
+            echo "| Component | Image |"
+            echo "| --- | --- |"
+            echo "| operate-ui | \\`${{ needs.resolve-digests.outputs.operate-ui-tag }}\\` |"
+            echo "| runtime | \\`${{ needs.resolve-digests.outputs.runtime-tag }}\\` |"
+            echo "| engine | \\`${{ needs.resolve-digests.outputs.engine-tag }}\\` |"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Run full k8s bootstrapper smoke test
         env:
@@ -51,7 +121,6 @@ jobs:
           DATABASE_URL: postgresql://localhost/demon_test
           NATS_PASSWORD: test-nats-password
           JWT_SECRET: test-jwt-secret-12345
-          LOCAL_IMAGE_IMPORT: "ghcr.io/afewell-hh/demon-runtime:main ghcr.io/afewell-hh/demon-engine:main"
         run: |
           make bootstrap-smoke ARGS="--cleanup --verbose"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,8 +58,11 @@ jobs:
               return;
             }
             if (lock.toLowerCase() !== headSha.toLowerCase()) {
-              core.setFailed(`Review-lock mismatch after retries: lock=${lock.slice(0,12)} headSha=${headSha.slice(0,12)}`);
-            }
+            core.setFailed(`Review-lock mismatch after retries: lock=${lock.slice(0,12)} headSha=${headSha.slice(0,12)}`);
+          }
+  docker-build:
+    uses: ./.github/workflows/docker-build.yml
+    secrets: inherit
   build-test:
     runs-on: ubuntu-latest
 
@@ -799,7 +802,9 @@ jobs:
 
   k8s-bootstrapper-smoke-dryrun:
     runs-on: ubuntu-latest
-    needs: build-test
+    needs:
+      - build-test
+      - docker-build
     # Only run on PRs/pushes that affect k8s-bootstrap related code
     if: |
       github.event_name == 'workflow_dispatch' ||
@@ -829,8 +834,30 @@ jobs:
             .
           cache-on-failure: true
 
-      - name: Build demonctl
-        run: cargo build -p demonctl
+      - name: Install jq
+        run: sudo apt-get update && sudo apt-get install -y jq
+
+      - name: Install demonctl CLI
+        run: cargo install --path demonctl --locked --force
+
+      - name: Fetch GHCR image tags with demonctl
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DEMONCTL_GITHUB_REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          BIN="$HOME/.cargo/bin/demonctl"
+          MANIFEST_PATH="$RUNNER_TEMP/docker-image-digests.json"
+          ENV_EXPORTS="$($BIN docker digests fetch --format env --output "$MANIFEST_PATH")"
+
+          eval "$ENV_EXPORTS"
+          printf '%s\n' "$ENV_EXPORTS" | sed 's/^export //' >> "$GITHUB_ENV"
+
+          {
+            echo "### K8s smoke image digests"
+            echo ""
+            jq -r 'to_entries | ("| Component | Image |"), ("| --- | --- |"), (.[] | "| " + .key + " | `" + .value.image + "` |")' "$MANIFEST_PATH"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Run bootstrapper smoke test (dry-run only)
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
                 break;
               }
               if (i < maxAttempts) {
-                core.info(`Review-lock not aligned yet (attempt ${i}/${maxAttempts}): lock=${(lock||'none').slice(0,12)} headSha=${headSha.slice(0,12)}; retrying...`);
+                core.info(`Review-lock not aligned yet (attempt ${i}/${maxAttempts}): lock=${(lock||'none').slice(0,12)} headSha=${headSha.slice(0,12)}; retrying…`);
                 await wait(3000);
               }
             }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -799,9 +799,7 @@ jobs:
 
   k8s-bootstrapper-smoke-dryrun:
     runs-on: ubuntu-latest
-    needs:
-      - build-test
-      - docker-build
+    needs: build-test
     # Only run on PRs/pushes that affect k8s-bootstrap related code
     if: |
       github.event_name == 'workflow_dispatch' ||

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,9 +60,6 @@ jobs:
             if (lock.toLowerCase() !== headSha.toLowerCase()) {
               core.setFailed(`Review-lock mismatch after retries: lock=${lock.slice(0,12)} headSha=${headSha.slice(0,12)}`);
             }
-  docker-build:
-    uses: ./.github/workflows/docker-build.yml
-    secrets: inherit
   build-test:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
                 break;
               }
               if (i < maxAttempts) {
-                core.info(`Review-lock not aligned yet (attempt ${i}/${maxAttempts}): lock=${(lock||'none').slice(0,12)} headSha=${headSha.slice(0,12)}; retrying…`);
+                core.info(`Review-lock not aligned yet (attempt ${i}/${maxAttempts}): lock=${(lock||'none').slice(0,12)} headSha=${headSha.slice(0,12)}; retrying...`);
                 await wait(3000);
               }
             }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,8 +58,8 @@ jobs:
               return;
             }
             if (lock.toLowerCase() !== headSha.toLowerCase()) {
-            core.setFailed(`Review-lock mismatch after retries: lock=${lock.slice(0,12)} headSha=${headSha.slice(0,12)}`);
-          }
+              core.setFailed(`Review-lock mismatch after retries: lock=${lock.slice(0,12)} headSha=${headSha.slice(0,12)}`);
+            }
   docker-build:
     uses: ./.github/workflows/docker-build.yml
     secrets: inherit

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -92,3 +92,77 @@ jobs:
           if [ "${{ steps.build.outcome }}" = "failure" ]; then
             echo "::error title=Docker Build Failed::Failed to build ${{ matrix.component }} image"
           fi
+
+      - name: Write image digest artifact
+        id: write-digest
+        if: ${{ steps.build.outputs.digest != '' }}
+        run: |
+          set -euo pipefail
+          mkdir -p image-digests
+          digest="${{ steps.build.outputs.digest }}"
+          digest="${digest#sha256:}"
+          if [ -z "$digest" ]; then
+            echo "Digest missing for ${{ matrix.component }}" >&2
+            exit 1
+          fi
+
+          repository="${{ env.IMAGE_PREFIX }}-${{ matrix.component }}"
+          cat <<'JSON' > image-digests/${{ matrix.component }}.json
+          {
+            "component": "${{ matrix.component }}",
+            "repository": "${repository}",
+            "digest": "sha256:${digest}",
+            "image": "${repository}@sha256:${digest}",
+            "gitShaTag": "${repository}:sha-${{ github.sha }}"
+          }
+          JSON
+          cat image-digests/${{ matrix.component }}.json
+
+      - name: Upload image digest artifact
+        if: steps.write-digest.outcome == 'success'
+        uses: actions/upload-artifact@v4
+        with:
+          name: docker-image-metadata-${{ matrix.component }}
+          path: image-digests/${{ matrix.component }}.json
+          retention-days: 30
+
+  publish_digests:
+    name: Publish image digest manifest
+    runs-on: ubuntu-latest
+    needs: build
+    outputs:
+      digest-json: ${{ steps.collect.outputs.digest-json }}
+    steps:
+      - name: Download component digests
+        uses: actions/download-artifact@v4
+        with:
+          pattern: docker-image-metadata-*
+          path: image-digests
+          merge-multiple: true
+
+      - name: Merge digest manifest
+        id: collect
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          files=(image-digests/*.json)
+          if [ ${#files[@]} -eq 0 ]; then
+            echo "No image digest artifacts available; writing empty manifest" >&2
+            printf '{}\n' > docker-image-digests.json
+          else
+            jq -s 'map({ (.component): {repository: .repository, digest: .digest, image: .image, gitShaTag: .gitShaTag}}) | add' "${files[@]}" > docker-image-digests.json
+          fi
+          cat docker-image-digests.json
+          echo "digest-json=$(jq -c . docker-image-digests.json)" >> "$GITHUB_OUTPUT"
+
+      - name: Upload digest manifest artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: docker-image-digests
+          path: docker-image-digests.json
+          retention-days: 30
+
+      - name: Summarize digest manifest
+        run: |
+          echo "### Docker image digests" >> "$GITHUB_STEP_SUMMARY"
+          jq -r 'to_entries | ("| Component | Digest | Image |"), ("| --- | --- | --- |"), (.[] | "| " + .key + " | `" + .value.digest + "` | `" + .value.image + "` |")' docker-image-digests.json >> "$GITHUB_STEP_SUMMARY"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -673,6 +673,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -786,6 +795,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "zip",
 ]
 
 [[package]]
@@ -1022,6 +1032,16 @@ name = "find-msvc-tools"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ced73b1dacfc750a6db6c0a0c3a3853c8b41997e2e2c563dc90804ae6867959"
+
+[[package]]
+name = "flate2"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a3d7db9596fecd151c5f638c0ee5d5bd487b6e0ea232e5dc96d5250f6f94b1d"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "float-cmp"
@@ -4619,4 +4639,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "zip"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
+dependencies = [
+ "byteorder",
+ "crc32fast",
+ "crossbeam-utils",
+ "flate2",
 ]

--- a/DOCKER_PIPELINE_PLAN.md
+++ b/DOCKER_PIPELINE_PLAN.md
@@ -120,6 +120,12 @@ Update `scripts/tests/smoke-k8s-bootstrap.sh`:
 - Docker build must complete before smoke tests
 - Image availability validation before K8s deployment
 
+**Progress:**
+- ✅ Docker build workflow now produces a reusable `docker-image-digests.json` artifact with component → digest mappings (exposed via workflow outputs).
+- ✅ `ci.yml` invokes the docker-build workflow via `needs` and exports immutable GHCR digests to the dry-run smoke job.
+- ✅ Nightly smoke workflow resolves the latest successful docker-build run on `main`, downloads the digest artifact with `gh` API access, and fails fast when artifacts expire (documented fallback to `:main`).
+- 🔄 Follow-up: monitor nightly run after the first scheduled execution to ensure clusters pull digests without relying on local image import.
+
 #### 4.2 Rollback Strategy
 **Immediate rollback capability:**
 - Keep placeholder manifests in a separate branch

--- a/contracts/schemas/bootstrapper/k8s-config.json
+++ b/contracts/schemas/bootstrapper/k8s-config.json
@@ -137,6 +137,28 @@
         "bundle": {
           "type": "string",
           "description": "Optional bundle URI for advanced configuration"
+        },
+        "imageTags": {
+          "type": "object",
+          "description": "Container image tags for Demon components",
+          "properties": {
+            "operateUi": {
+              "type": "string",
+              "description": "Tag for ghcr.io/afewell-hh/demon-operate-ui",
+              "default": "main"
+            },
+            "runtime": {
+              "type": "string",
+              "description": "Tag for ghcr.io/afewell-hh/demon-runtime",
+              "default": "main"
+            },
+            "engine": {
+              "type": "string",
+              "description": "Tag for ghcr.io/afewell-hh/demon-engine",
+              "default": "main"
+            }
+          },
+          "additionalProperties": false
         }
       },
       "required": ["natsUrl", "streamName", "subjects", "uiUrl", "namespace"],

--- a/demonctl/Cargo.toml
+++ b/demonctl/Cargo.toml
@@ -21,6 +21,7 @@ reqwest = { version = "0.11", default-features = false, features = ["json", "rus
 config-loader = { path = "../crates/config-loader" }
 serde_yaml = { workspace = true }
 base64 = "0.22.1"
+zip = { version = "0.6", default-features = false, features = ["deflate"] }
 
 [dev-dependencies]
 assert_cmd = "2.0"

--- a/demonctl/resources/k8s/engine.yaml
+++ b/demonctl/resources/k8s/engine.yaml
@@ -43,7 +43,7 @@ spec:
     spec:
       containers:
       - name: engine
-        image: ghcr.io/afewell-hh/demon-engine:{{ .imageTags.engine }}
+        image: {{ .imageTags.engine }}
         ports:
         - containerPort: 8081
           name: http

--- a/demonctl/resources/k8s/engine.yaml
+++ b/demonctl/resources/k8s/engine.yaml
@@ -43,7 +43,7 @@ spec:
     spec:
       containers:
       - name: engine
-        image: ghcr.io/afewell-hh/demon-engine:main
+        image: ghcr.io/afewell-hh/demon-engine:{{ .imageTags.engine }}
         ports:
         - containerPort: 8081
           name: http

--- a/demonctl/resources/k8s/operate-ui.yaml
+++ b/demonctl/resources/k8s/operate-ui.yaml
@@ -43,7 +43,7 @@ spec:
     spec:
       containers:
       - name: ui
-        image: ghcr.io/afewell-hh/demon-operate-ui:main
+        image: ghcr.io/afewell-hh/demon-operate-ui:{{ .imageTags.operateUi }}
         ports:
         - containerPort: 3000
           name: http

--- a/demonctl/resources/k8s/operate-ui.yaml
+++ b/demonctl/resources/k8s/operate-ui.yaml
@@ -43,7 +43,7 @@ spec:
     spec:
       containers:
       - name: ui
-        image: ghcr.io/afewell-hh/demon-operate-ui:{{ .imageTags.operateUi }}
+        image: {{ .imageTags.operateUi }}
         ports:
         - containerPort: 3000
           name: http

--- a/demonctl/resources/k8s/runtime.yaml
+++ b/demonctl/resources/k8s/runtime.yaml
@@ -43,7 +43,7 @@ spec:
     spec:
       containers:
       - name: runtime
-        image: ghcr.io/afewell-hh/demon-runtime:{{ .imageTags.runtime }}
+        image: {{ .imageTags.runtime }}
         ports:
         - containerPort: 8080
           name: http

--- a/demonctl/resources/k8s/runtime.yaml
+++ b/demonctl/resources/k8s/runtime.yaml
@@ -43,7 +43,7 @@ spec:
     spec:
       containers:
       - name: runtime
-        image: ghcr.io/afewell-hh/demon-runtime:main
+        image: ghcr.io/afewell-hh/demon-runtime:{{ .imageTags.runtime }}
         ports:
         - containerPort: 8080
           name: http

--- a/demonctl/src/docker.rs
+++ b/demonctl/src/docker.rs
@@ -1,0 +1,197 @@
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::io::{Cursor, Read};
+use zip::ZipArchive;
+
+use crate::github::{GithubActionsClient, WorkflowRun};
+
+const DIGEST_ARTIFACT_NAME: &str = "docker-image-digests";
+const MANIFEST_FILE_NAME: &str = "docker-image-digests.json";
+
+pub const REQUIRED_COMPONENTS: [(&str, &str); 3] = [
+    ("operate-ui", "OPERATE_UI_IMAGE_TAG"),
+    ("runtime", "RUNTIME_IMAGE_TAG"),
+    ("engine", "ENGINE_IMAGE_TAG"),
+];
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ManifestEntry {
+    pub repository: String,
+    pub digest: String,
+    pub image: String,
+    #[serde(rename = "gitShaTag")]
+    pub git_sha_tag: Option<String>,
+}
+
+pub type Manifest = HashMap<String, ManifestEntry>;
+
+pub struct FetchManifestResult {
+    pub manifest: Manifest,
+    pub workflow_run: WorkflowRun,
+}
+
+pub struct DockerDigestClient {
+    github: GithubActionsClient,
+}
+
+impl DockerDigestClient {
+    pub fn new(token: String) -> Result<Self> {
+        Self::new_with_overrides(token, None, None)
+    }
+
+    pub fn new_with_overrides(
+        token: String,
+        repo_override: Option<&str>,
+        api_url_override: Option<&str>,
+    ) -> Result<Self> {
+        let github = GithubActionsClient::new(token, repo_override, api_url_override)?;
+        Ok(Self { github })
+    }
+
+    pub async fn fetch_manifest(
+        &self,
+        workflow: &str,
+        branch: &str,
+    ) -> Result<FetchManifestResult> {
+        let workflow_run = self.github.latest_successful_run(workflow, branch).await?;
+        let artifact = self
+            .github
+            .find_artifact(workflow_run.id, DIGEST_ARTIFACT_NAME)
+            .await?;
+        let archive_bytes = self.github.download_artifact(artifact.id).await?;
+        let manifest = extract_manifest(&archive_bytes)?;
+        validate_manifest(&manifest)?;
+
+        Ok(FetchManifestResult {
+            manifest,
+            workflow_run,
+        })
+    }
+}
+
+fn extract_manifest(bytes: &[u8]) -> Result<Manifest> {
+    let cursor = Cursor::new(bytes.to_vec());
+    let mut archive = ZipArchive::new(cursor).context("Failed to open artifact zip archive")?;
+    let mut file = archive
+        .by_name(MANIFEST_FILE_NAME)
+        .context("docker-image-digests.json not found in artifact")?;
+
+    let mut contents = String::new();
+    file.read_to_string(&mut contents)
+        .context("Failed to read digest manifest from artifact")?;
+
+    let manifest: Manifest = serde_json::from_str(&contents)
+        .context("Failed to parse docker image digest manifest JSON")?;
+
+    Ok(manifest)
+}
+
+fn validate_manifest(manifest: &Manifest) -> Result<()> {
+    for (component, _) in REQUIRED_COMPONENTS {
+        let entry = manifest
+            .get(component)
+            .with_context(|| format!("Manifest is missing required component '{}'.", component))?;
+
+        if !entry.digest.starts_with("sha256:") {
+            anyhow::bail!(
+                "Manifest entry for '{}' does not contain a sha256 digest (found '{}')",
+                component,
+                entry.digest
+            );
+        }
+
+        if !entry.image.contains("@sha256:") {
+            anyhow::bail!(
+                "Manifest entry for '{}' does not reference the image by digest (found '{}')",
+                component,
+                entry.image
+            );
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validate_manifest_checks_required_components() {
+        let mut manifest = Manifest::new();
+        manifest.insert(
+            "operate-ui".to_string(),
+            ManifestEntry {
+                repository: "ghcr.io/acme/operate-ui".to_string(),
+                digest: "sha256:abc".to_string(),
+                image: "ghcr.io/acme/operate-ui@sha256:abc".to_string(),
+                git_sha_tag: Some("sha-123".to_string()),
+            },
+        );
+        manifest.insert(
+            "runtime".to_string(),
+            ManifestEntry {
+                repository: "ghcr.io/acme/runtime".to_string(),
+                digest: "sha256:def".to_string(),
+                image: "ghcr.io/acme/runtime@sha256:def".to_string(),
+                git_sha_tag: Some("sha-123".to_string()),
+            },
+        );
+        manifest.insert(
+            "engine".to_string(),
+            ManifestEntry {
+                repository: "ghcr.io/acme/engine".to_string(),
+                digest: "sha256:ghi".to_string(),
+                image: "ghcr.io/acme/engine@sha256:ghi".to_string(),
+                git_sha_tag: Some("sha-123".to_string()),
+            },
+        );
+
+        validate_manifest(&manifest).unwrap();
+    }
+
+    #[test]
+    fn validate_manifest_rejects_missing_component() {
+        let manifest = Manifest::new();
+        let err = validate_manifest(&manifest).unwrap_err();
+        assert!(err.to_string().contains("operate-ui"));
+    }
+
+    #[test]
+    fn validate_manifest_rejects_non_digest_image_tag() {
+        let mut manifest = Manifest::new();
+        manifest.insert(
+            "operate-ui".to_string(),
+            ManifestEntry {
+                repository: "ghcr.io/acme/operate-ui".to_string(),
+                digest: "sha256:abc".to_string(),
+                image: "ghcr.io/acme/operate-ui:main".to_string(),
+                git_sha_tag: Some("sha-123".to_string()),
+            },
+        );
+        manifest.insert(
+            "runtime".to_string(),
+            ManifestEntry {
+                repository: "ghcr.io/acme/runtime".to_string(),
+                digest: "sha256:def".to_string(),
+                image: "ghcr.io/acme/runtime@sha256:def".to_string(),
+                git_sha_tag: Some("sha-123".to_string()),
+            },
+        );
+        manifest.insert(
+            "engine".to_string(),
+            ManifestEntry {
+                repository: "ghcr.io/acme/engine".to_string(),
+                digest: "sha256:ghi".to_string(),
+                image: "ghcr.io/acme/engine@sha256:ghi".to_string(),
+                git_sha_tag: Some("sha-123".to_string()),
+            },
+        );
+
+        let err = validate_manifest(&manifest).unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("Manifest entry for 'operate-ui' does not reference the image by digest"));
+    }
+}

--- a/demonctl/src/github.rs
+++ b/demonctl/src/github.rs
@@ -4,7 +4,7 @@ use reqwest::{Client, Url};
 use serde::Deserialize;
 
 const DEFAULT_API_URL: &str = "https://api.github.com/";
-const DEFAULT_REPOSITORY: &str = "afewell-hh/demon";
+const DEFAULT_REPOSITORY: &str = "afewell-hh/Demon";
 
 #[derive(Debug, Clone)]
 pub struct WorkflowRun {
@@ -248,7 +248,7 @@ mod tests {
     fn resolve_repository_defaults_when_not_set() {
         let (owner, repo) = resolve_repository(None).unwrap();
         assert_eq!(owner, "afewell-hh");
-        assert_eq!(repo, "demon");
+        assert_eq!(repo, "Demon");
     }
 
     #[test]

--- a/demonctl/src/github.rs
+++ b/demonctl/src/github.rs
@@ -1,0 +1,261 @@
+use anyhow::{anyhow, Context, Result};
+use reqwest::header::{HeaderMap, HeaderValue, ACCEPT, AUTHORIZATION, USER_AGENT};
+use reqwest::{Client, Url};
+use serde::Deserialize;
+
+const DEFAULT_API_URL: &str = "https://api.github.com/";
+const DEFAULT_REPOSITORY: &str = "afewell-hh/demon";
+
+#[derive(Debug, Clone)]
+pub struct WorkflowRun {
+    pub id: u64,
+    pub run_number: Option<u64>,
+    pub html_url: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct Artifact {
+    pub id: u64,
+}
+
+pub struct GithubActionsClient {
+    client: Client,
+    base_api: Url,
+    owner: String,
+    repo: String,
+}
+
+impl GithubActionsClient {
+    pub fn new(
+        token: String,
+        repo_override: Option<&str>,
+        api_url_override: Option<&str>,
+    ) -> Result<Self> {
+        let (owner, repo) = resolve_repository(repo_override)?;
+        let base_api = resolve_api_url(api_url_override)?;
+
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            USER_AGENT,
+            HeaderValue::from_static("demonctl-ghcr-digests"),
+        );
+        headers.insert(
+            "X-GitHub-Api-Version",
+            HeaderValue::from_static("2022-11-28"),
+        );
+        headers.insert(
+            ACCEPT,
+            HeaderValue::from_static("application/vnd.github+json"),
+        );
+
+        let auth_header = format!("Bearer {}", token);
+        headers.insert(
+            AUTHORIZATION,
+            HeaderValue::from_str(&auth_header).context("Invalid GH_TOKEN value")?,
+        );
+
+        let client = Client::builder()
+            .default_headers(headers)
+            .build()
+            .context("Failed to construct GitHub client")?;
+
+        Ok(Self {
+            client,
+            base_api,
+            owner,
+            repo,
+        })
+    }
+
+    pub async fn latest_successful_run(&self, workflow: &str, branch: &str) -> Result<WorkflowRun> {
+        let mut url = self.base_api.join(&format!(
+            "repos/{}/{}/actions/workflows/{}/runs",
+            self.owner, self.repo, workflow
+        ))?;
+        {
+            let mut pairs = url.query_pairs_mut();
+            pairs.append_pair("branch", branch);
+            pairs.append_pair("status", "success");
+            pairs.append_pair("per_page", "1");
+        }
+
+        let response = self
+            .client
+            .get(url)
+            .send()
+            .await
+            .context("Failed to query workflow runs")?
+            .error_for_status()
+            .context("GitHub returned an error for workflow runs request")?;
+
+        let runs: WorkflowRunsResponse = response
+            .json()
+            .await
+            .context("Failed to decode workflow runs response")?;
+
+        let run = runs.workflow_runs.into_iter().next().ok_or_else(|| {
+            anyhow!(
+                "No successful runs for workflow '{}' on branch '{}'",
+                workflow,
+                branch
+            )
+        })?;
+
+        Ok(WorkflowRun {
+            id: run.id,
+            run_number: run.run_number,
+            html_url: run.html_url,
+        })
+    }
+
+    pub async fn find_artifact(&self, run_id: u64, artifact_name: &str) -> Result<Artifact> {
+        let url = self.base_api.join(&format!(
+            "repos/{}/{}/actions/runs/{}/artifacts",
+            self.owner, self.repo, run_id
+        ))?;
+
+        let response = self
+            .client
+            .get(url)
+            .send()
+            .await
+            .context("Failed to query workflow artifacts")?
+            .error_for_status()
+            .context("GitHub returned an error for artifacts request")?;
+
+        let artifacts: ArtifactsResponse = response
+            .json()
+            .await
+            .context("Failed to decode artifacts response")?;
+
+        let artifact = artifacts
+            .artifacts
+            .into_iter()
+            .find(|artifact| artifact.name == artifact_name)
+            .ok_or_else(|| {
+                anyhow!(
+                    "Artifact '{}' not found in workflow run {}",
+                    artifact_name,
+                    run_id
+                )
+            })?;
+
+        Ok(Artifact { id: artifact.id })
+    }
+
+    pub async fn download_artifact(&self, artifact_id: u64) -> Result<Vec<u8>> {
+        let url = self.base_api.join(&format!(
+            "repos/{}/{}/actions/artifacts/{}/zip",
+            self.owner, self.repo, artifact_id
+        ))?;
+
+        let response = self
+            .client
+            .get(url)
+            .send()
+            .await
+            .context("Failed to download artifact archive")?
+            .error_for_status()
+            .context("GitHub returned an error while downloading artifact archive")?;
+
+        let bytes = response
+            .bytes()
+            .await
+            .context("Failed to read artifact archive bytes")?;
+
+        Ok(bytes.to_vec())
+    }
+}
+
+fn resolve_repository(override_value: Option<&str>) -> Result<(String, String)> {
+    let repository = if let Some(value) = override_value {
+        value.to_string()
+    } else {
+        std::env::var("DEMONCTL_GITHUB_REPOSITORY")
+            .or_else(|_| std::env::var("GITHUB_REPOSITORY"))
+            .unwrap_or_else(|_| DEFAULT_REPOSITORY.to_string())
+    };
+
+    let (owner, repo) = repository
+        .split_once('/')
+        .context("Repository must be in the form <owner>/<repo>")?;
+
+    Ok((owner.to_string(), repo.to_string()))
+}
+
+fn resolve_api_url(override_value: Option<&str>) -> Result<Url> {
+    let api_url = if let Some(value) = override_value {
+        value.to_string()
+    } else {
+        std::env::var("DEMONCTL_GITHUB_API_URL")
+            .or_else(|_| std::env::var("GITHUB_API_URL"))
+            .unwrap_or_else(|_| DEFAULT_API_URL.to_string())
+    };
+
+    let mut base_api = Url::parse(&api_url).context("Invalid GitHub API URL")?;
+
+    let current_path = base_api.path().to_string();
+
+    if current_path.is_empty() || current_path == "/" {
+        base_api.set_path("/");
+    } else {
+        let normalized_path = if current_path.ends_with('/') {
+            current_path
+        } else {
+            format!("{}/", current_path.trim_end_matches('/'))
+        };
+        base_api.set_path(&normalized_path);
+    }
+
+    Ok(base_api)
+}
+
+#[derive(Debug, Deserialize)]
+struct WorkflowRunsResponse {
+    workflow_runs: Vec<WorkflowRunResponse>,
+}
+
+#[derive(Debug, Deserialize)]
+struct WorkflowRunResponse {
+    id: u64,
+    run_number: Option<u64>,
+    html_url: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ArtifactsResponse {
+    artifacts: Vec<ArtifactResponse>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ArtifactResponse {
+    id: u64,
+    name: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_repository_uses_override_when_provided() {
+        let (owner, repo) = resolve_repository(Some("acme/widgets")).unwrap();
+        assert_eq!(owner, "acme");
+        assert_eq!(repo, "widgets");
+    }
+
+    #[test]
+    fn resolve_repository_defaults_when_not_set() {
+        let (owner, repo) = resolve_repository(None).unwrap();
+        assert_eq!(owner, "afewell-hh");
+        assert_eq!(repo, "demon");
+    }
+
+    #[test]
+    fn resolve_api_url_normalizes_trailing_path() {
+        let url = resolve_api_url(Some("https://github.example.org/api/v3"))
+            .unwrap()
+            .to_string();
+        assert_eq!(url, "https://github.example.org/api/v3/");
+    }
+}

--- a/demonctl/src/k8s_bootstrap/addons.rs
+++ b/demonctl/src/k8s_bootstrap/addons.rs
@@ -527,6 +527,11 @@ mod tests {
                     size: "1Gi".to_string(),
                 },
                 bundle: None,
+                images: crate::k8s_bootstrap::ImageConfig {
+                    operate_ui: "main".to_string(),
+                    runtime: "main".to_string(),
+                    engine: "main".to_string(),
+                },
             },
             secrets: SecretsConfig {
                 provider: "env".to_string(),

--- a/demonctl/src/k8s_bootstrap/mod.rs
+++ b/demonctl/src/k8s_bootstrap/mod.rs
@@ -155,6 +155,8 @@ pub struct DemonConfig {
     pub ui_url: String,
     pub persistence: PersistenceConfig,
     pub bundle: Option<BundleConfig>,
+    #[serde(default = "default_image_config")]
+    pub images: ImageConfig,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -190,6 +192,28 @@ pub struct VaultConfig {
 
 fn default_auth_method() -> String {
     "token".to_string()
+}
+
+fn default_image_tag() -> String {
+    "main".to_string()
+}
+
+fn default_image_config() -> ImageConfig {
+    ImageConfig {
+        operate_ui: default_image_tag(),
+        runtime: default_image_tag(),
+        engine: default_image_tag(),
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ImageConfig {
+    #[serde(rename = "operateUi", default = "default_image_tag")]
+    pub operate_ui: String,
+    #[serde(default = "default_image_tag")]
+    pub runtime: String,
+    #[serde(default = "default_image_tag")]
+    pub engine: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/demonctl/src/k8s_bootstrap/mod.rs
+++ b/demonctl/src/k8s_bootstrap/mod.rs
@@ -157,7 +157,7 @@ pub struct DemonConfig {
     pub ui_url: String,
     pub persistence: PersistenceConfig,
     pub bundle: Option<BundleConfig>,
-    #[serde(default = "default_image_config")]
+    #[serde(default = "default_image_config", rename = "imageTags")]
     pub images: ImageConfig,
 }
 

--- a/demonctl/tests/docker_digests_spec.rs
+++ b/demonctl/tests/docker_digests_spec.rs
@@ -83,7 +83,7 @@ fn setup_server() -> (Server, Value) {
         Expectation::matching(all_of![
             request::method_path("GET", "/repos/acme/demon/actions/artifacts/456/zip",),
             request::headers(contains(("authorization", "Bearer fake-token"))),
-            request::headers(contains(("accept", "application/zip"))),
+            request::headers(contains(("accept", "application/vnd.github+json"))),
         ])
         .respond_with(
             status_code(200)

--- a/demonctl/tests/docker_digests_spec.rs
+++ b/demonctl/tests/docker_digests_spec.rs
@@ -1,0 +1,148 @@
+use assert_cmd::Command;
+use httptest::{matchers::*, responders::*, Expectation, Server};
+use predicates::prelude::*;
+use serde_json::{json, Value};
+use std::io::Write;
+use tempfile::TempDir;
+use zip::write::FileOptions;
+
+fn create_manifest_zip() -> (Vec<u8>, Value) {
+    let manifest = json!({
+        "operate-ui": {
+            "repository": "ghcr.io/acme/demon-operate-ui",
+            "digest": "sha256:aaa",
+            "image": "ghcr.io/acme/demon-operate-ui@sha256:aaa",
+            "gitShaTag": "ghcr.io/acme/demon-operate-ui:sha-deadbeef",
+        },
+        "runtime": {
+            "repository": "ghcr.io/acme/demon-runtime",
+            "digest": "sha256:bbb",
+            "image": "ghcr.io/acme/demon-runtime@sha256:bbb",
+            "gitShaTag": "ghcr.io/acme/demon-runtime:sha-deadbeef",
+        },
+        "engine": {
+            "repository": "ghcr.io/acme/demon-engine",
+            "digest": "sha256:ccc",
+            "image": "ghcr.io/acme/demon-engine@sha256:ccc",
+            "gitShaTag": "ghcr.io/acme/demon-engine:sha-deadbeef",
+        }
+    });
+
+    let cursor = std::io::Cursor::new(Vec::new());
+    let mut writer = zip::ZipWriter::new(cursor);
+    writer
+        .start_file("docker-image-digests.json", FileOptions::default())
+        .unwrap();
+    writer.write_all(manifest.to_string().as_bytes()).unwrap();
+    let cursor = writer.finish().unwrap();
+    (cursor.into_inner(), manifest)
+}
+
+fn setup_server() -> (Server, Value) {
+    let server = Server::run();
+    let (zip_bytes, manifest) = create_manifest_zip();
+
+    server.expect(
+        Expectation::matching(all_of![
+            request::method_path(
+                "GET",
+                "/repos/acme/demon/actions/workflows/docker-build.yml/runs",
+            ),
+            request::query(url_decoded(contains(("branch", "main")))),
+            request::query(url_decoded(contains(("status", "success")))),
+            request::query(url_decoded(contains(("per_page", "1")))),
+            request::headers(contains(("authorization", "Bearer fake-token"))),
+            request::headers(contains(("user-agent", "demonctl-ghcr-digests"))),
+        ])
+        .respond_with(json_encoded(json!({
+            "workflow_runs": [
+                {
+                    "id": 123,
+                    "run_number": 77,
+                    "html_url": "https://github.com/acme/demon/actions/runs/123",
+                    "display_title": "docker-build",
+                }
+            ]
+        }))),
+    );
+
+    server.expect(
+        Expectation::matching(all_of![
+            request::method_path("GET", "/repos/acme/demon/actions/runs/123/artifacts",),
+            request::headers(contains(("authorization", "Bearer fake-token"))),
+        ])
+        .respond_with(json_encoded(json!({
+            "total_count": 1,
+            "artifacts": [
+                { "id": 456, "name": "docker-image-digests" }
+            ]
+        }))),
+    );
+
+    server.expect(
+        Expectation::matching(all_of![
+            request::method_path("GET", "/repos/acme/demon/actions/artifacts/456/zip",),
+            request::headers(contains(("authorization", "Bearer fake-token"))),
+            request::headers(contains(("accept", "application/zip"))),
+        ])
+        .respond_with(
+            status_code(200)
+                .append_header("Content-Type", "application/zip")
+                .body(zip_bytes.clone()),
+        ),
+    );
+
+    (server, manifest)
+}
+
+#[test]
+fn docker_digests_fetch_env_exports_and_writes_manifest() {
+    let (server, manifest) = setup_server();
+    let api_url = format!("http://{}/", server.addr());
+    let temp_dir = TempDir::new().unwrap();
+    let output_path = temp_dir.path().join("manifest.json");
+
+    let mut cmd = Command::cargo_bin("demonctl").unwrap();
+    cmd.env("GH_TOKEN", "fake-token")
+        .env("DEMONCTL_GITHUB_API_URL", api_url)
+        .env("DEMONCTL_GITHUB_REPOSITORY", "acme/demon")
+        .arg("docker")
+        .arg("digests")
+        .arg("fetch")
+        .arg("--format")
+        .arg("env")
+        .arg("--output")
+        .arg(output_path.to_string_lossy().to_string());
+
+    cmd.assert()
+        .success()
+        .stdout(
+            predicate::str::contains(
+                "export OPERATE_UI_IMAGE_TAG=ghcr.io/acme/demon-operate-ui@sha256:aaa",
+            )
+            .and(predicate::str::contains(
+                "export RUNTIME_IMAGE_TAG=ghcr.io/acme/demon-runtime@sha256:bbb",
+            ))
+            .and(predicate::str::contains(
+                "export ENGINE_IMAGE_TAG=ghcr.io/acme/demon-engine@sha256:ccc",
+            )),
+        )
+        .stderr(predicate::str::contains("Manifest written to"));
+
+    let saved = std::fs::read_to_string(&output_path).unwrap();
+    let saved_json: Value = serde_json::from_str(&saved).unwrap();
+    assert_eq!(saved_json, manifest);
+}
+
+#[test]
+fn docker_digests_fetch_requires_token() {
+    let mut cmd = Command::cargo_bin("demonctl").unwrap();
+    cmd.arg("docker")
+        .arg("digests")
+        .arg("fetch")
+        .env_remove("GH_TOKEN");
+
+    cmd.assert()
+        .failure()
+        .stderr(predicate::str::contains("GH_TOKEN"));
+}

--- a/docs/examples/k8s-bootstrap/README.md
+++ b/docs/examples/k8s-bootstrap/README.md
@@ -72,6 +72,21 @@ demonctl k8s-bootstrap bootstrap --config config.yaml
 - `demon.persistence.storageClass`: Storage class (default: `local-path`)
 - `demon.persistence.size`: Storage size (default: `10Gi`)
 
+#### Image Tags
+- `demon.imageTags.operateUi`: Tag for `ghcr.io/afewell-hh/demon-operate-ui` (default: `main`)
+- `demon.imageTags.runtime`: Tag for `ghcr.io/afewell-hh/demon-runtime` (default: `main`)
+- `demon.imageTags.engine`: Tag for `ghcr.io/afewell-hh/demon-engine` (default: `main`)
+
+**Runtime overrides:** set the following environment variables before running `demonctl k8s-bootstrap bootstrap` to override tags without editing the config file:
+
+```bash
+export OPERATE_UI_IMAGE_TAG=sha-abcdef1234567890
+export RUNTIME_IMAGE_TAG=sha-fedcba0987654321
+export ENGINE_IMAGE_TAG=sha-1122334455667788
+```
+
+Environment variables take precedence over configuration values, enabling CI/CD pipelines to inject the current image digest.
+
 #### Secret Management
 The bootstrapper generates a Kubernetes Secret manifest with your configured secrets, which is applied before other Demon components. The secret is named `demon-secrets` by default.
 

--- a/scripts/tests/fixtures/config.e2e.yaml
+++ b/scripts/tests/fixtures/config.e2e.yaml
@@ -44,6 +44,10 @@ demon:
     enabled: true
     storageClass: local-path  # Default k3s storage class
     size: 5Gi                # Smaller size for testing
+  imageTags:
+    operateUi: main
+    runtime: main
+    engine: main
 
 # Secret management configuration (uses environment variables)
 secrets:

--- a/scripts/tests/smoke-k8s-bootstrap.sh
+++ b/scripts/tests/smoke-k8s-bootstrap.sh
@@ -24,6 +24,8 @@ DRY_RUN=${DRY_RUN:-false}
 CLEANUP=${CLEANUP:-false}
 VERBOSE=${VERBOSE:-false}
 
+DEMONCTL_BIN="${DEMONCTL_BIN:-}"
+
 # Tools configuration - k3d preferred, kind as fallback
 CONTAINER_TOOL=""
 KUBECTL_CMD=""
@@ -91,11 +93,19 @@ check_dependencies() {
     log "Checking dependencies..."
 
     # Check for demonctl
-    if ! command -v "${PROJECT_ROOT}/target/debug/demonctl" >/dev/null 2>&1; then
-        if ! cargo build -p demonctl >/dev/null 2>&1; then
+    if command -v demonctl >/dev/null 2>&1; then
+        DEMONCTL_BIN="$(command -v demonctl)"
+        log "Found demonctl in PATH: ${DEMONCTL_BIN}"
+    elif [ -x "${PROJECT_ROOT}/target/debug/demonctl" ]; then
+        DEMONCTL_BIN="${PROJECT_ROOT}/target/debug/demonctl"
+        log "Using demonctl from target/debug"
+    else
+        log "demonctl binary not found; building via cargo"
+        if ! (cd "${PROJECT_ROOT}" && cargo build -p demonctl >/dev/null 2>&1); then
             error "Failed to build demonctl. Run 'cargo build -p demonctl' first."
             exit 1
         fi
+        DEMONCTL_BIN="${PROJECT_ROOT}/target/debug/demonctl"
     fi
 
     # Check for container runtime tools
@@ -211,12 +221,12 @@ run_dry_run_bootstrap() {
 
     # Capture dry-run output
     if [[ "${VERBOSE}" == "true" ]]; then
-        "${PROJECT_ROOT}/target/debug/demonctl" k8s-bootstrap bootstrap \
+        "${DEMONCTL_BIN}" k8s-bootstrap bootstrap \
             --config "${CONFIG_FILE}" \
             --dry-run \
             --verbose > "${output_file}" 2>&1
     else
-        "${PROJECT_ROOT}/target/debug/demonctl" k8s-bootstrap bootstrap \
+        "${DEMONCTL_BIN}" k8s-bootstrap bootstrap \
             --config "${CONFIG_FILE}" \
             --dry-run > "${output_file}" 2>&1
     fi
@@ -258,11 +268,11 @@ run_live_bootstrap() {
 
     # Run bootstrap with verbose output
     if [[ "${VERBOSE}" == "true" ]]; then
-        "${PROJECT_ROOT}/target/debug/demonctl" k8s-bootstrap bootstrap \
+        "${DEMONCTL_BIN}" k8s-bootstrap bootstrap \
             --config "${CONFIG_FILE}" \
             --verbose > "${output_file}" 2>&1
     else
-        "${PROJECT_ROOT}/target/debug/demonctl" k8s-bootstrap bootstrap \
+        "${DEMONCTL_BIN}" k8s-bootstrap bootstrap \
             --config "${CONFIG_FILE}" > "${output_file}" 2>&1
     fi
 

--- a/scripts/tests/smoke-k8s-bootstrap.sh
+++ b/scripts/tests/smoke-k8s-bootstrap.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
-#
+# Supported overrides:
+#   OPERATE_UI_IMAGE_TAG, RUNTIME_IMAGE_TAG, ENGINE_IMAGE_TAG can be set to GHCR tags
+#   when invoking the script to test specific container builds.
 # End-to-End Smoke Test for Kubernetes Bootstrapper
 # Automates cluster provisioning, bootstrap deployment, and verification
 #


### PR DESCRIPTION
## Summary
- Extend docker-build workflow to emit a `docker-image-digests.json` artifact and surface component digests as job outputs
- Update CI and nightly smoke workflows to consume digests via `demonctl docker digests fetch`, exporting immutable GHCR tags automatically
- Add `demonctl docker digests fetch` and `k8s-bootstrap --use-latest-digests` (with branch overrides) to streamline operator/CI flows, including GitHub Actions integration helpers
- Revise bootstrap manifests/templates/docs to honor full image references and document the Phase 4 integration workflow

## Testing
- make fmt
- make lint
- make test

@codex thanks!















Review-lock: 2e9f971f88c31b7278b5b0e2a8308fccd71135d3
