### PR TITLE
fix(docker): enable shell variable expansion in digest artifacts

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -107,7 +107,7 @@ jobs:
           fi
 
           repository="${{ env.IMAGE_PREFIX }}-${{ matrix.component }}"
-          cat <<'JSON' > image-digests/${{ matrix.component }}.json
+          cat <<JSON > image-digests/${{ matrix.component }}.json
           {
             "component": "${{ matrix.component }}",
             "repository": "${repository}",


### PR DESCRIPTION
## Summary
Fixes critical bug in docker-build.yml where heredoc quoting prevented shell variable expansion in digest artifacts.

## Problem
The heredoc marker used single quotes (`cat <<'JSON'`) which prevents shell variable substitution. This resulted in all digest artifacts containing literal template strings like `${repository}` and `${digest}` instead of actual values.

## Solution
Remove quotes from heredoc marker (line 110): `cat <<'JSON'` → `cat <<JSON`

## Impact
- Next docker-build run will produce properly formatted digest manifests
- `demonctl docker digests fetch` will receive actual digest values instead of templates
- CI workflows (`ci.yml`, `bootstrapper-smoke.yml`) will function correctly with digest resolution

## Validation
Per issue #228 validation:
- ✅ Main-branch build [#18239570085](https://github.com/afewell-hh/Demon/actions/runs/18239570085) completed successfully (~3 hours multi-arch)
- ✅ Bootstrap dry-run confirmed end-to-end flow works
- ✅ Digests manually extracted from logs as workaround:
  - operate-ui: `sha256:34b1eb2bf9528eb01f9a06c2e2fc16a257d5653405b19ba4254b10faa54d2b5a`
  - runtime: `sha256:66f72381156386cfa59a60a8e710815544e00ca20f0e0e55038d48ab187a51a2`
  - engine: `sha256:93b0e5743caae6114c4b9f495066043d7c52e93a9aafd17fc146db7cfd547bd1`

## Testing
- `make fmt` ✅
- `make lint` ✅  
- `make test` ✅ (2 pre-existing flaky unit tests in demonctl unrelated to this change)

## Checklist
- [x] Small, focused change (~1 line code + validation docs)
- [x] Links to issue #228
- [x] Validation evidence provided
- [x] Tests passing (ignoring pre-existing flakes)

Fixes #228