### PR TITLE
feat(container-exec): implement sandboxed container execution capsule

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -458,6 +458,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "capsules_container_exec"
+version = "0.0.1"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "envelope",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror 1.0.69",
+ "tracing",
+]
+
+[[package]]
 name = "capsules_echo"
 version = "0.0.1"
 dependencies = [
@@ -781,11 +795,14 @@ dependencies = [
  "base64 0.22.1",
  "bootstrapper-demonctl",
  "capsules_graph",
+ "chrono",
  "clap",
  "config-loader",
  "engine",
  "envelope",
  "httptest",
+ "jsonschema 0.18.3",
+ "once_cell",
  "predicates",
  "reqwest 0.11.27",
  "serde",
@@ -2824,6 +2841,7 @@ dependencies = [
  "async-nats",
  "async-stream",
  "axum",
+ "capsules_container_exec",
  "capsules_echo",
  "capsules_graph",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
   "runtime",
   "wards",
   "capsules/echo",
+  "capsules/container-exec",
   "capsules/graph",
   "demonctl",
   "operate-ui",

--- a/capsules/container-exec/Cargo.toml
+++ b/capsules/container-exec/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "capsules_container_exec"
+version = "0.0.1"
+edition = "2021"
+license.workspace = true
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+anyhow = { workspace = true }
+chrono = { workspace = true }
+envelope = { path = "../../crates/envelope" }
+serde = { workspace = true }
+serde_json = { workspace = true }
+tempfile = "3.10"
+thiserror = { workspace = true }
+tracing = { workspace = true }

--- a/capsules/container-exec/README.md
+++ b/capsules/container-exec/README.md
@@ -1,0 +1,53 @@
+# Container Exec Capsule
+
+The container-exec capsule provides a sandboxed execution primitive for Demon
+App Packs. It runs digest-pinned container images with hardened runtime flags,
+collects stdout/stderr for diagnostics, and materializes Explainable Result
+Envelopes from a shared bind mount.
+
+## Features
+
+- Enforces digest-pinned images (`@sha256:<digest>`)
+- Locks down the container (`--network=none`, `--read-only`, `--tmpfs /tmp`,
+  `--security-opt=no-new-privileges`, non-root user)
+- Captures stdout/stderr and exit code as diagnostics
+- Reads the result envelope from the declared `outputs.envelopePath`
+- Validates the envelope against the platform schema
+- Emits canonical error envelopes when the runtime, envelope, or configuration
+  fail
+- Supports a `stub` runtime for local testing (set `DEMON_CONTAINER_RUNTIME=stub`
+  and point `DEMON_CONTAINER_EXEC_STUB_ENVELOPE` to an envelope JSON file)
+
+## Usage
+
+```rust
+use capsules_container_exec::{execute, ContainerExecConfig};
+use std::collections::BTreeMap;
+
+let config = ContainerExecConfig {
+    image_digest: "ghcr.io/example/app@sha256:...".into(),
+    command: vec!["/bin/run".into()],
+    env: BTreeMap::new(),
+    working_dir: None,
+    envelope_path: "/workspace/.artifacts/result.json".into(),
+    capsule_name: Some("sample".into()),
+};
+
+let envelope = execute(&config);
+// Serialize envelope back to the runtime caller
+```
+
+## Environment Overrides
+
+- `DEMON_CONTAINER_RUNTIME` — container binary to execute (default: `docker`).
+  Set to `stub` when running without a container runtime.
+- `DEMON_CONTAINER_EXEC_STUB_ENVELOPE` — path to an envelope JSON file that is
+  returned when `DEMON_CONTAINER_RUNTIME=stub`.
+- `DEMON_CONTAINER_USER` — user (`uid:gid`) to run containers as (default:
+  `65534:65534`).
+
+## Future Work
+
+- Optional support for additional capsule outputs (artifacts, logs)
+- Toggleable rootless runtimes (e.g., `nerdctl`, `podman`)
+- Streaming log diagnostics back to callers

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -20,6 +20,7 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 capsules_echo = { path = "../capsules/echo" }
 capsules_graph = { path = "../capsules/graph" }
+capsules_container_exec = { path = "../capsules/container-exec" }
 async-nats = { workspace = true }
 tokio = { workspace = true }
 chrono = { workspace = true }

--- a/runtime/tests/container_exec_dispatch_spec.rs
+++ b/runtime/tests/container_exec_dispatch_spec.rs
@@ -1,0 +1,43 @@
+use runtime::link::router::Router;
+use serde_json::json;
+use std::fs::File;
+use std::io::Write;
+
+#[tokio::test]
+async fn dispatch_container_exec_stub_returns_envelope() {
+    let router = Router::new();
+    let temp_dir = tempfile::tempdir().unwrap();
+    let stub_path = temp_dir.path().join("stub-envelope.json");
+
+    let envelope = envelope::ResultEnvelope::builder()
+        .success(json!({"ok": true}))
+        .build()
+        .unwrap();
+    let mut file = File::create(&stub_path).unwrap();
+    file.write_all(serde_json::to_vec(&envelope).unwrap().as_slice())
+        .unwrap();
+
+    std::env::set_var("DEMON_CONTAINER_RUNTIME", "stub");
+    std::env::set_var(
+        "DEMON_CONTAINER_EXEC_STUB_ENVELOPE",
+        stub_path.to_string_lossy().to_string(),
+    );
+
+    let args = json!({
+        "imageDigest": "ghcr.io/demo/app@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+        "command": ["/bin/true"],
+        "outputs": {"envelopePath": "/workspace/result.json"},
+        "env": {},
+        "capsuleName": "test-capsule"
+    });
+
+    let response = router
+        .dispatch("container-exec", &args, "run-1", "ritual-1")
+        .await
+        .unwrap();
+
+    std::env::remove_var("DEMON_CONTAINER_RUNTIME");
+    std::env::remove_var("DEMON_CONTAINER_EXEC_STUB_ENVELOPE");
+
+    assert!(response.get("result").is_some());
+}


### PR DESCRIPTION
## Summary
- add the `capsules/container-exec` crate with sandboxed Docker runtime wrapper
- validate Explainable Result Envelopes and emit canonical error envelopes
- wire runtime link router dispatch and add stub-mode integration test

## Testing
- cargo fmt
- cargo check
- cargo test *(fails: linker reports "No space left on device" while compiling operate-ui tests; needs workspace cleanup before re-run)*

Fixes #238

@codex review