### PR TITLE
feat(schema): allow runtime/count metrics in result envelopes

### DIFF
--- a/contracts/envelopes/result.json
+++ b/contracts/envelopes/result.json
@@ -182,6 +182,24 @@
             "type": "integer"
           }
         },
+        "runtime": {
+          "type": "object",
+          "description": "Runtime subsystem metrics (structured data reported by capsules/runtime)",
+          "additionalProperties": true
+        },
+        "counts": {
+          "type": "object",
+          "description": "Aggregated count metrics keyed by category",
+          "additionalProperties": {
+            "anyOf": [
+              { "type": "number" },
+              {
+                "type": "object",
+                "additionalProperties": true
+              }
+            ]
+          }
+        },
         "custom": {
           "type": "object",
           "description": "Custom application-specific metrics",

--- a/contracts/fixtures/envelopes/result_full.json
+++ b/contracts/fixtures/envelopes/result_full.json
@@ -111,6 +111,32 @@
       "cache_hits": 89,
       "cache_misses": 61
     },
+    "runtime": {
+      "capsule": {
+        "image": "ghcr.io/hoss/hfab@sha256:abc123",
+        "exitCode": 0,
+        "duration_ms": 68432
+      },
+      "runtime": {
+        "scheduler": {
+          "queueDepth": 2,
+          "workerCount": 4
+        }
+      }
+    },
+    "counts": {
+      "artifacts": {
+        "written": 5,
+        "uploaded": 4
+      },
+      "steps": {
+        "completed": {
+          "total": 12,
+          "retry": 1
+        },
+        "failed": 0
+      }
+    },
     "custom": {
       "business_value_generated": 15000.50,
       "api_calls_made": 25,

--- a/demonctl/tests/contracts_validate_spec.rs
+++ b/demonctl/tests/contracts_validate_spec.rs
@@ -92,6 +92,46 @@ fn given_invalid_envelope_on_stdin_when_validate_then_exits_with_error() {
 }
 
 #[test]
+fn given_envelope_with_runtime_and_counts_when_validate_then_exits_successfully() {
+    let temp_dir = TempDir::new().unwrap();
+    let file_path = temp_dir.path().join("metrics_envelope.json");
+
+    let envelope = json!({
+        "result": {
+            "success": true,
+            "data": {"message": "ok"}
+        },
+        "metrics": {
+            "runtime": {
+                "capsule": {
+                    "name": "hoss-hfab",
+                    "duration_ms": 1234
+                }
+            },
+            "counts": {
+                "artifacts": {
+                    "written": 5,
+                    "uploaded": 4
+                }
+            }
+        }
+    });
+
+    fs::write(&file_path, serde_json::to_string(&envelope).unwrap()).unwrap();
+
+    Command::cargo_bin("demonctl")
+        .unwrap()
+        .args([
+            "contracts",
+            "validate-envelope",
+            file_path.to_str().unwrap(),
+        ])
+        .assert()
+        .success()
+        .stdout(str::contains("✓ Valid envelope"));
+}
+
+#[test]
 fn given_directory_with_result_files_when_bulk_validate_then_processes_all() {
     let temp_dir = TempDir::new().unwrap();
 

--- a/docs/app-packs/schema.md
+++ b/docs/app-packs/schema.md
@@ -64,6 +64,15 @@ Cards enable the Operate UI to render manifest-driven views without shipping app
 
 Operate UI will ingest these manifests at install time and render cards dynamically.
 
+## Result Envelope Metrics
+
+Capsules should continue to emit Explainable Result Envelopes that conform to `contracts/envelopes/result.json`. In addition to the existing `duration`, `resources`, `counters`, and `custom` objects, the platform now accepts two structured metrics blocks:
+
+- `metrics.runtime` — container/runtime level measurements (e.g., capsule timings, scheduler metadata). This is an open-ended object so capsules can project whatever nested structure is useful for operators.
+- `metrics.counts` — grouped counter summaries keyed by subsystem. Each entry may be a primitive value or a nested object (for example, `{ "artifacts": { "written": 5, "uploaded": 4 } }`).
+
+These additions were introduced to support Hoss hhfab telemetry and are optional for other packs.
+
 ## Contracts
 
 Contract entries reference JSON schema or fixture assets bundled with the pack. Paths must live under `contracts/` inside the bundle. Contracts are registered under the pack namespace during installation so they can be queried via the Contracts API.


### PR DESCRIPTION
## Summary
- update `contracts/envelopes/result.json` to accept `metrics.runtime` and `metrics.counts`
- extend `result_full` fixture plus CLI validation tests to cover the new metrics structures
- document the optional metrics blocks for App Pack authors and Hoss

Fixes #248

## Testing
- cargo fmt
- cargo test -p demonctl contracts_validate_spec
