### PR TITLE
fix(container-exec): allow alias envelope writes

### DIFF
--- a/capsules/container-exec/src/lib.rs
+++ b/capsules/container-exec/src/lib.rs
@@ -82,6 +82,14 @@ impl ContainerExecConfig {
                     format!("Failed to create artifacts directory '{}'", dir.display())
                 })?;
             }
+
+            #[cfg(unix)]
+            fs::set_permissions(dir, fs::Permissions::from_mode(0o777)).with_context(|| {
+                format!(
+                    "Failed to set permissions on artifacts directory '{}'",
+                    dir.display()
+                )
+            })?;
         }
 
         Ok(())

--- a/demonctl/tests/run_alias_permissions_spec.rs
+++ b/demonctl/tests/run_alias_permissions_spec.rs
@@ -1,0 +1,121 @@
+#![cfg(unix)]
+
+use anyhow::Result;
+use assert_cmd::prelude::*;
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use tempfile::TempDir;
+
+fn workspace_root() -> PathBuf {
+    Path::new(&std::env::var("CARGO_MANIFEST_DIR").unwrap())
+        .ancestors()
+        .nth(1)
+        .unwrap()
+        .to_path_buf()
+}
+
+#[test]
+fn run_alias_persists_envelope_with_custom_runtime() -> Result<()> {
+    let temp = TempDir::new()?;
+    let app_home = temp.path().join("app-home");
+    fs::create_dir_all(&app_home)?;
+
+    let pack_dir = temp.path().join("pack");
+    fs::create_dir_all(pack_dir.join("contracts/hoss"))?;
+    fs::write(pack_dir.join("contracts/hoss/result.json"), b"{}")?;
+    fs::write(
+        pack_dir.join("app-pack.yaml"),
+        r#"apiVersion: demon.io/v1
+kind: AppPack
+metadata:
+  name: hoss
+  version: 0.1.0
+contracts:
+  - id: hoss/contracts/result
+    version: 0.1.0
+    path: contracts/hoss/result.json
+capsules:
+  - type: container-exec
+    name: validator
+    imageDigest: ghcr.io/example/validator@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    command:
+      - /bin/sh
+      - -c
+      - "exit 0"
+    outputs:
+      envelopePath: /workspace/.artifacts/summary.json
+rituals:
+  - name: hoss-validate
+    steps:
+      - capsule: validator
+"#,
+    )?;
+
+    let runtime_bin = temp.path().join("fake-docker.sh");
+    fs::write(
+        &runtime_bin,
+        r##"#!/usr/bin/env bash
+set -euo pipefail
+
+host=""
+envelope=""
+args=("$@")
+for ((i=0; i<${#args[@]}; i++)); do
+  arg="${args[$i]}"
+  if [[ "$arg" == "--mount" ]]; then
+    i=$((i+1))
+    mount="${args[$i]}"
+    if [[ "$mount" == type=bind,source=* ]] && [[ "$mount" == *,target=/workspace/.artifacts* ]]; then
+      host="${mount#type=bind,source=}"
+      host="${host%%,target=*}"
+    fi
+  elif [[ "$arg" == "--env" ]]; then
+    i=$((i+1))
+    envspec="${args[$i]}"
+    if [[ "$envspec" == ENVELOPE_PATH=* ]]; then
+      envelope="${envspec#ENVELOPE_PATH=}"
+    fi
+  fi
+done
+
+if [[ -z "$host" || -z "$envelope" ]]; then
+  echo "missing mount or envelope" >&2
+  exit 1
+fi
+
+rel="${envelope#/workspace/.artifacts/}"
+if [[ "$rel" == "$envelope" ]]; then
+  rel="${envelope#/}"
+fi
+
+mkdir -p "$(dirname "$host/$rel")"
+cat > "$host/$rel" <<'JSON'
+{"result":{"success":true,"data":{"source":"fake-runtime"}}}
+JSON
+
+exit 0
+"##,
+    )?;
+    fs::set_permissions(&runtime_bin, fs::Permissions::from_mode(0o755))?;
+
+    let workspace = workspace_root();
+
+    Command::cargo_bin("demonctl")?
+        .current_dir(&workspace)
+        .env("DEMON_APP_HOME", &app_home)
+        .args(["app", "install", pack_dir.to_str().unwrap()])
+        .assert()
+        .success();
+
+    Command::cargo_bin("demonctl")?
+        .current_dir(&workspace)
+        .env("DEMON_APP_HOME", &app_home)
+        .env("DEMON_CONTAINER_RUNTIME", runtime_bin.as_os_str())
+        .args(["run", "hoss:hoss-validate"])
+        .assert()
+        .success();
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- chmod artifacts directories inside container-exec validation before the runtime spins up
- add an alias regression test that exercises `demonctl run hoss:hoss-validate` with a fake docker runtime that writes the envelope

Fixes #250

## Testing
- cargo fmt
- cargo clippy -- -D warnings
- cargo test -p capsules_container_exec
- cargo test -p runtime container_exec_dispatch_spec
- cargo test -p demonctl run_alias_persists_envelope_with_custom_runtime

Review-lock: 48d55746f2beefdb98dff6086a5654a56f2ccc02
