### PR TITLE
fix(container-exec): keep alias envelopes readable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -500,6 +500,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "envelope",
+ "libc",
  "serde",
  "serde_json",
  "tempfile",

--- a/capsules/container-exec/Cargo.toml
+++ b/capsules/container-exec/Cargo.toml
@@ -16,3 +16,6 @@ serde_json = { workspace = true }
 tempfile = "3.10"
 thiserror = { workspace = true }
 tracing = { workspace = true }
+
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"

--- a/capsules/container-exec/src/lib.rs
+++ b/capsules/container-exec/src/lib.rs
@@ -473,7 +473,23 @@ fn configure_command(
 }
 
 fn container_user() -> String {
-    env::var("DEMON_CONTAINER_USER").unwrap_or_else(|_| "65534:65534".to_string())
+    if let Ok(value) = env::var("DEMON_CONTAINER_USER") {
+        if !value.trim().is_empty() {
+            return value;
+        }
+    }
+
+    #[cfg(unix)]
+    {
+        let uid = unsafe { libc::geteuid() };
+        let gid = unsafe { libc::getegid() };
+        format!("{}:{}", uid, gid)
+    }
+
+    #[cfg(not(unix))]
+    {
+        "65534:65534".to_string()
+    }
 }
 
 fn exit_code(status: &ExitStatus) -> Option<i32> {

--- a/demonctl/tests/run_alias_permissions_spec.rs
+++ b/demonctl/tests/run_alias_permissions_spec.rs
@@ -2,6 +2,7 @@
 
 use anyhow::Result;
 use assert_cmd::prelude::*;
+use serde_json::Value;
 use std::fs;
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
@@ -116,6 +117,97 @@ exit 0
         .args(["run", "hoss:hoss-validate"])
         .assert()
         .success();
+
+    Ok(())
+}
+
+#[test]
+fn run_alias_emits_envelope_with_real_runtime() -> Result<()> {
+    if Command::new("docker")
+        .arg("--version")
+        .output()
+        .map(|out| out.status.success())
+        .unwrap_or(false)
+        == false
+    {
+        return Ok(());
+    }
+
+    let temp = TempDir::new()?;
+    let app_home = temp.path().join("app-home");
+    fs::create_dir_all(&app_home)?;
+
+    let pack_dir = temp.path().join("pack");
+    fs::create_dir_all(pack_dir.join("contracts/test"))?;
+    fs::write(pack_dir.join("contracts/test/result.json"), b"{}")?;
+
+    let status = Command::new("docker")
+        .args(["pull", "alpine:3.20"])
+        .status()?;
+    if !status.success() {
+        anyhow::bail!("docker pull alpine:3.20 failed");
+    }
+
+    let alpine_digest = "docker.io/library/alpine@sha256:b3119ef930faabb6b7b976780c0c7a9c1aa24d0c75e9179ac10e6bc9ac080d0d";
+
+    let manifest = format!(
+        r#"apiVersion: demon.io/v1
+kind: AppPack
+metadata:
+  name: hoss
+  version: 0.1.0
+contracts:
+  - id: hoss/contracts/result
+    version: 0.1.0
+    path: contracts/test/result.json
+capsules:
+  - type: container-exec
+    name: validator
+    imageDigest: {digest}
+    command:
+      - /bin/sh
+      - -c
+      - "umask 077 && printf '{{\"result\":{{\"success\":true,\"data\":{{}}}},\"diagnostics\":[]}}' > \"$ENVELOPE_PATH\""
+    outputs:
+      envelopePath: /workspace/.artifacts/summary.json
+rituals:
+  - name: hoss-validate
+    steps:
+      - capsule: validator
+"#,
+        digest = alpine_digest
+    );
+
+    fs::write(pack_dir.join("app-pack.yaml"), manifest)?;
+
+    let workspace = workspace_root();
+
+    Command::cargo_bin("demonctl")?
+        .current_dir(&workspace)
+        .env("DEMON_APP_HOME", &app_home)
+        .args([
+            "app",
+            "install",
+            pack_dir.join("app-pack.yaml").to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+
+    let output = Command::cargo_bin("demonctl")?
+        .current_dir(&workspace)
+        .env("DEMON_APP_HOME", &app_home)
+        .args(["run", "hoss:hoss-validate"])
+        .output()?;
+
+    assert!(output.status.success(), "demonctl run failed: {:?}", output);
+
+    let value: Value = serde_json::from_slice(&output.stdout)?;
+    assert_eq!(
+        value["outputs"]["result"]["success"].as_bool(),
+        Some(true),
+        "alias run should succeed: {}",
+        value
+    );
 
     Ok(())
 }


### PR DESCRIPTION
## Summary
- default the container runtime user to the host UID/GID when `DEMON_CONTAINER_USER` is unset so envelope files remain readable
- add integration coverage for `demonctl run hoss:hoss-validate` using Docker (with restrictive umask) to ensure the alias path writes and returns the envelope

Fixes #252

## Testing
- cargo fmt
- cargo clippy -- -D warnings
- cargo test -p capsules_container_exec
- cargo test -p runtime container_exec_dispatch_spec
- cargo test -p demonctl --test run_alias_permissions_spec
