### PR TITLE
container-exec(debug): DEMON_DEBUG pre/post-run diagnostics

### DIFF
--- a/capsules/container-exec/src/lib.rs
+++ b/capsules/container-exec/src/lib.rs
@@ -687,6 +687,15 @@ fn command_line_string(cmd: &Command) -> String {
 }
 
 fn annotate_host_postrun(envelope: &mut Envelope, host_path: &Path, cmdline: &str) {
+    // Always include the runtime command line when debugging
+    envelope.diagnostics.push(
+        Diagnostic::info(format!(
+            "runtime command: {}",
+            truncate(cmdline, 1024)
+        ))
+        .with_source("container-exec"),
+    );
+
     let ls_output = Command::new("/bin/ls")
         .arg("-l")
         .arg(host_path)


### PR DESCRIPTION
Implements diagnostics for Demon#257 under DEMON_DEBUG gate.\n\n- Pre-run (inside container): user/group, ENVELOPE_PATH, parent ls, writability check, mount table\n- Post-run (host): ls -l + stat of host envelope file; include runtime command when size==0\n\nRefs #257