### PR TITLE
container-exec: clear image ENTRYPOINT with --entrypoint="" (Fixes #259)

### DIFF
--- a/capsules/container-exec/README.md
+++ b/capsules/container-exec/README.md
@@ -17,6 +17,10 @@ Envelopes from a shared bind mount.
   fail
 - Supports a `stub` runtime for local testing (set `DEMON_CONTAINER_RUNTIME=stub`
   and point `DEMON_CONTAINER_EXEC_STUB_ENVELOPE` to an envelope JSON file)
+ - Clears image `ENTRYPOINT` (`--entrypoint ""`) so the capsule's declared
+   command is executed exactly as provided. This avoids Docker's
+   `ENTRYPOINT + CMD` concatenation which can break read-only filesystems or
+   wrapper shells.
 
 ## Envelope Write Semantics (non-root containers)
 
@@ -69,6 +73,15 @@ let config = ContainerExecConfig {
 let envelope = execute(&config);
 // Serialize envelope back to the runtime caller
 ```
+
+### Entrypoint Behavior
+
+Some images define an `ENTRYPOINT` like `/bin/bash -lc`. By default, Docker
+concatenates `ENTRYPOINT` and the runtime `CMD`, altering how commands execute
+and sometimes preventing writes on hardened, read-only filesystems. The
+container-exec capsule explicitly passes `--entrypoint ""` before the image
+reference so that only the capsule's `command` runs. Images without an
+`ENTRYPOINT` are unaffected.
 
 ## Environment Overrides
 


### PR DESCRIPTION
HOSS Day 7 revealed images with a login-shell ENTRYPOINT (e.g., [/bin/bash,-lc]) cause docker to concatenate ENTRYPOINT+CMD, breaking our app-provided command under RO filesystems.\n\nChange\n- Pass --entrypoint "" before the image digest so the capsule command runs exactly as declared.\n\nAcceptance\n- Alias run succeeds with hhfab image; non-empty envelope produced.\n- Images without ENTRYPOINT unaffected.\n- Documented in container-exec README.\n\nFixes #259

Review-lock: 69d8f963ef0db3487cd1eaa3327be0b662880482
\n<!-- touch: retrigger review-lock -->