### PR TITLE
docs: clarify App Pack mounts + troubleshoot script path (Fixes #266)

### DIFF
--- a/capsules/container-exec/README.md
+++ b/capsules/container-exec/README.md
@@ -52,6 +52,13 @@ Troubleshooting:
   ensure the App Pack was prepared via `demonctl app install` (the runtime will
   pre-create the container-side target automatically during execution).
   Inspect the host-side artifacts directory for the bound file if debugging.
+ - "script not found under /workspace/capsules": the container command in your
+   capsule likely references a path like `/workspace/capsules/<name>/scripts/*.sh`.
+   This path exists only when the App Pack tree is installed and mounted at
+   `/workspace` (read-only). Fix by installing the pack with `demonctl app install`
+   and invoking the ritual via `demonctl run <app>:<ritual>`. Do not reference the
+   source tree paths directly — the runtime resolves capsule scripts relative to
+   the installed App Pack mounted at `/workspace`.
 
 ## Usage
 

--- a/demonctl/README.md
+++ b/demonctl/README.md
@@ -23,6 +23,21 @@ cargo run -p demonctl -- run examples/rituals/echo.yaml
 cargo run -p demonctl -- --help
 ```
 
+## Installed App Pack Mounts
+
+When you run a ritual from an installed App Pack (e.g., `demonctl run hoss:hoss-validate`),
+the runtime mounts the pack into the container with hardened settings:
+
+- App Pack root is mounted read-only at `/workspace`.
+- The pack’s artifacts directory is mounted read-write at `/workspace/.artifacts`.
+- A direct file bind is added from the host placeholder to the container target
+  envelope path (e.g., `/workspace/.artifacts/result.json`) to guarantee writes
+  with non-root users.
+
+Capsule commands should reference scripts relative to `/workspace`, for example:
+`/workspace/capsules/<capsule>/scripts/run.sh`. If you see "script not found",
+ensure you installed the pack via `demonctl app install <pack_dir>` before running.
+
 ## See Also
 
 - [Main README](../README.md) — Project overview and quickstart


### PR DESCRIPTION
This PR updates documentation to complete Demon#266 Scope (Docs & troubleshooting):

- Container Exec README: adds explicit troubleshooting for "script not found under /workspace/capsules" and reiterates mount semantics.
- demonctl README: documents installed App Pack mount behavior (/workspace ro, /workspace/.artifacts rw, direct file bind to envelope).

No code changes; docs-only.

Review-lock: 52884c7b42be8dd62763c3a06f445f2d2a8be610
