### PR TITLE
test(container-exec): assert resource flags precede image (Fixes #276)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,4 +38,7 @@ health-check-*.md
 # Local Rust toolchains (never commit)
 .rustup/
 
+# Cargo local cache (never commit)
+.cargo/
+
 # trigger CI


### PR DESCRIPTION
Adds an order assertion that --cpus/--memory/--pids-limit occur before the image in the docker run invocation. Prevents regressions of #270/#274.

Review-lock: 77c4d0eca3dea33bf9b9fd0679e3891b867e4a32